### PR TITLE
fix: FilteredROOC index broken when the source collection item remove

### DIFF
--- a/Source/ReactiveProperty.Portable-NET45+WINRT+WP8/Helpers/FilteredReadOnlyObservableCollection.cs
+++ b/Source/ReactiveProperty.Portable-NET45+WINRT+WP8/Helpers/FilteredReadOnlyObservableCollection.cs
@@ -114,9 +114,9 @@ namespace Reactive.Bindings.Helpers
                             case NotifyCollectionChangedAction.Remove:
                                 var removedIndex = this.indexList[x.OldStartingIndex];
                                 this.indexList.RemoveAt(x.OldStartingIndex);
-                                this.DisappearItem(x.OldStartingIndex);
                                 if (removedIndex.HasValue)
                                 {
+                                    this.DisappearItem(x.OldStartingIndex);
                                     this.OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Remove,
                                         x.OldItems.Cast<TElement>().Single(), removedIndex.Value));
                                 }


### PR DESCRIPTION
FilteredReadOnlyObservableCollectionのソースコレクションからアイテムを削除すると、indexListが壊れる事があるのを修正しました。

ソースコレクションのアイテムを削除すると、その項目に対応するindexListのアイテムを削除して、以降のindexListのアイテムを更新(値がある場合は-1)しています。
削除されたアイテムがfilterによって除外される項目の場合、indexListのアイテムを更新するとindexListが不正な状態となります。