### PR TITLE
fix: FilteredROOC index broken when the source collection item replace

### DIFF
--- a/Source/ReactiveProperty.Portable-NET45+WINRT+WP8/Helpers/FilteredReadOnlyObservableCollection.cs
+++ b/Source/ReactiveProperty.Portable-NET45+WINRT+WP8/Helpers/FilteredReadOnlyObservableCollection.cs
@@ -138,6 +138,8 @@ namespace Reactive.Bindings.Helpers
                                 else if (index.HasValue && !isTarget)
                                 {
                                     // remove
+                                    this.indexList[x.NewStartingIndex] = null;
+                                    this.DisappearItem(x.NewStartingIndex);
                                     this.OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Remove,
                                         x.OldItems.Cast<TElement>().Single(), index.Value));
                                 }


### PR DESCRIPTION
FilteredReadOnlyObservableCollectionのソースコレクションのアイテムを入れ替えると、indexListが壊れる事があるのを修正しました。

ソースコレクションのアイテムを入れ替える時に、入れ替える前のアイテムはfilterによって除外されない項目、入れ替えた後のアイテムはfilterによって除外される項目の場合、FilteredROOCにとってはアイテムの削除になります。
しかし、indexListの更新を行っていないため、indexListが不正な状態となります。

また、indexListが不正な状態となるため、列挙結果も不正となります。
GetEnumerator()でindexListを参照して値を列挙しているため、列挙した結果のオブジェクト数とCountプロパティの値が一致しなくなります。
(Countプロパティの値は正しく更新されています)