### PR TITLE
Make IReadOnlyReactiveProperty vary covariantly

### DIFF
--- a/Source/ReactiveProperty.Portable-NET45+WINRT+WP8/IReadOnlyReactiveProperty.cs
+++ b/Source/ReactiveProperty.Portable-NET45+WINRT+WP8/IReadOnlyReactiveProperty.cs
@@ -12,7 +12,7 @@ namespace Reactive.Bindings
         object Value { get; }
     }
 
-    public interface IReadOnlyReactiveProperty<T> : IReadOnlyReactiveProperty, IObservable<T>, INotifyPropertyChanged, IDisposable
+    public interface IReadOnlyReactiveProperty<out T> : IReadOnlyReactiveProperty, IObservable<T>, INotifyPropertyChanged, IDisposable
     {
         new T Value { get; }
     }


### PR DESCRIPTION
This is a generally useful change. An example of code that is only possible with this change:

    public ReactiveProperty<SettingsTabViewModel> SettingsTab { get; }
    public IReadOnlyReactiveProperty<TabViewModel> DefaultSelectedTab => SettingsTab;
