### PR TITLE
Add MessageBroker, AsyncMessageBroker

### DIFF
--- a/Source/ReactiveProperty.Portable-NET45+WINRT+WP8/Notifiers/MessageBroker.cs
+++ b/Source/ReactiveProperty.Portable-NET45+WINRT+WP8/Notifiers/MessageBroker.cs
@@ -1,0 +1,359 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reactive.Linq;
+using System.Threading.Tasks;
+
+namespace Reactive.Bindings.Notifiers
+{
+    /// <summary>
+    /// In-Memory PubSub filtered by Type.
+    /// </summary>
+    public interface IMessagePublisher
+    {
+        /// <summary>
+        /// Send Message to all receiver.
+        /// </summary>
+        void Publish<T>(T message);
+    }
+
+    /// <summary>
+    /// In-Memory PubSub filtered by Type.
+    /// </summary>
+    public interface IMessageSubscriber
+    {
+        /// <summary>
+        /// Subscribe typed message.
+        /// </summary>
+        IDisposable Subscribe<T>(Action<T> action);
+    }
+
+    /// <summary>
+    /// In-Memory PubSub filtered by Type.
+    /// </summary>
+    public interface IMessageBroker : IMessagePublisher, IMessageSubscriber
+    {
+    }
+
+    /// <summary>
+    /// In-Memory PubSub filtered by Type.
+    /// </summary>
+    public interface IAsyncMessagePublisher
+    {
+        /// <summary>
+        /// Send Message to all receiver and await complete.
+        /// </summary>
+        Task PublishAsync<T>(T message);
+    }
+
+    public interface IAsyncMessageSubscriber
+    {
+        /// <summary>
+        /// Subscribe typed message.
+        /// </summary>
+        IDisposable Subscribe<T>(Func<T, Task> asyncAction);
+    }
+
+    public interface IAsyncMessageBroker : IAsyncMessagePublisher, IAsyncMessageSubscriber
+    {
+    }
+
+    /// <summary>
+    /// In-Memory PubSub filtered by Type.
+    /// </summary>
+    public class MessageBroker : IMessageBroker, IDisposable
+    {
+        /// <summary>
+        /// MessageBroker in Global scope.
+        /// </summary>
+        public static readonly IMessageBroker Default = new MessageBroker();
+
+        bool isDisposed = false;
+        readonly Dictionary<Type, object> notifiers = new Dictionary<Type, object>();
+
+        /// <summary>
+        /// Send Message to all receiver.
+        /// </summary>
+        public void Publish<T>(T message)
+        {
+            ImmutableList<Action<T>> notifier;
+            lock (notifiers)
+            {
+                if (isDisposed) throw new ObjectDisposedException("AsyncMessageBroker");
+
+                object _notifier;
+                if (notifiers.TryGetValue(typeof(T), out _notifier))
+                {
+                    notifier = (ImmutableList<Action<T>>)_notifier;
+                }
+                else
+                {
+                    return;
+                }
+            }
+
+            var data = notifier.Data;
+            for (int i = 0; i < data.Length; i++)
+            {
+                data[i].Invoke(message);
+            }
+        }
+
+        /// <summary>
+        /// Subscribe typed message.
+        /// </summary>
+        public IDisposable Subscribe<T>(Action<T> action)
+        {
+            lock (notifiers)
+            {
+                if (isDisposed) throw new ObjectDisposedException("MessageBroker");
+
+                object _notifier;
+                if (!notifiers.TryGetValue(typeof(T), out _notifier))
+                {
+                    var notifier = ImmutableList<Action<T>>.Empty;
+                    notifier = notifier.Add(action);
+                    notifiers.Add(typeof(T), notifier);
+                }
+                else
+                {
+                    var notifier = (ImmutableList<Action<T>>)_notifier;
+                    notifier = notifier.Add(action);
+                    notifiers[typeof(T)] = notifier;
+                }
+            }
+
+            return new Subscription<T>(this, action);
+        }
+
+        /// <summary>
+        /// Stop Pub-Sub system.
+        /// </summary>
+        public void Dispose()
+        {
+            lock (notifiers)
+            {
+                if (!isDisposed)
+                {
+                    isDisposed = true;
+                    notifiers.Clear();
+                }
+            }
+        }
+
+        class Subscription<T> : IDisposable
+        {
+            readonly MessageBroker parent;
+            readonly Action<T> action;
+
+            public Subscription(MessageBroker parent, Action<T> action)
+            {
+                this.parent = parent;
+                this.action = action;
+            }
+
+            public void Dispose()
+            {
+                lock (parent.notifiers)
+                {
+                    object _notifier;
+                    if (parent.notifiers.TryGetValue(typeof(T), out _notifier))
+                    {
+                        var notifier = (ImmutableList<Action<T>>)_notifier;
+                        notifier = notifier.Remove(action);
+
+                        parent.notifiers[typeof(T)] = notifier;
+                    }
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// In-Memory PubSub filtered by Type.
+    /// </summary>
+    public class AsyncMessageBroker : IAsyncMessageBroker, IDisposable
+    {
+        static readonly Task EmptyTask = Task.FromResult<object>(null);
+
+        /// <summary>
+        /// AsyncMessageBroker in Global scope.
+        /// </summary>
+        public static readonly IAsyncMessageBroker Default = new AsyncMessageBroker();
+
+        bool isDisposed = false;
+        readonly Dictionary<Type, object> notifiers = new Dictionary<Type, object>();
+
+        /// <summary>
+        /// Send Message to all receiver and await complete.
+        /// </summary>
+        public Task PublishAsync<T>(T message)
+        {
+            ImmutableList<Func<T, Task>> notifier;
+            lock (notifiers)
+            {
+                if (isDisposed) throw new ObjectDisposedException("AsyncMessageBroker");
+
+                object _notifier;
+                if (notifiers.TryGetValue(typeof(T), out _notifier))
+                {
+                    notifier = (ImmutableList<Func<T, Task>>)_notifier;
+                }
+                else
+                {
+                    return EmptyTask;
+                }
+            }
+
+            var data = notifier.Data;
+            var awaiter = new Task[data.Length];
+            for (int i = 0; i < data.Length; i++)
+            {
+                awaiter[i] = data[i].Invoke(message);
+            }
+            return Task.WhenAll(awaiter);
+        }
+
+        /// <summary>
+        /// Subscribe typed message.
+        /// </summary>
+        public IDisposable Subscribe<T>(Func<T, Task> asyncAction)
+        {
+            lock (notifiers)
+            {
+                if (isDisposed) throw new ObjectDisposedException("AsyncMessageBroker");
+
+                object _notifier;
+                if (!notifiers.TryGetValue(typeof(T), out _notifier))
+                {
+                    var notifier = ImmutableList<Func<T, Task>>.Empty;
+                    notifier = notifier.Add(asyncAction);
+                    notifiers.Add(typeof(T), notifier);
+                }
+                else
+                {
+                    var notifier = (ImmutableList<Func<T, Task>>)_notifier;
+                    notifier = notifier.Add(asyncAction);
+                    notifiers[typeof(T)] = notifier;
+                }
+            }
+
+            return new Subscription<T>(this, asyncAction);
+        }
+
+        /// <summary>
+        /// Stop Pub-Sub system.
+        /// </summary>
+        public void Dispose()
+        {
+            lock (notifiers)
+            {
+                if (!isDisposed)
+                {
+                    isDisposed = true;
+                    notifiers.Clear();
+                }
+            }
+        }
+
+        class Subscription<T> : IDisposable
+        {
+            readonly AsyncMessageBroker parent;
+            readonly Func<T, Task> asyncAction;
+
+            public Subscription(AsyncMessageBroker parent, Func<T, Task> asyncAction)
+            {
+                this.parent = parent;
+                this.asyncAction = asyncAction;
+            }
+
+            public void Dispose()
+            {
+                lock (parent.notifiers)
+                {
+                    object _notifier;
+                    if (parent.notifiers.TryGetValue(typeof(T), out _notifier))
+                    {
+                        var notifier = (ImmutableList<Func<T, Task>>)_notifier;
+                        notifier = notifier.Remove(asyncAction);
+
+                        parent.notifiers[typeof(T)] = notifier;
+                    }
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Extensions of MessageBroker.
+    /// </summary>
+    public static class MessageBrokerExtensions
+    {
+        /// <summary>
+        /// Convert IMessageSubscriber.Subscribe to Observable.
+        /// </summary>
+        public static IObservable<T> ToObservable<T>(this IMessageSubscriber messageSubscriber)
+        {
+            return Observable.Create<T>(observer =>
+            {
+                var d = messageSubscriber.Subscribe<T>(x => observer.OnNext(x));
+                return d;
+            });
+        }
+    }
+
+    // ImmutableList is from Rx internal
+    internal class ImmutableList<T>
+    {
+        public static readonly ImmutableList<T> Empty = new ImmutableList<T>();
+
+        T[] data;
+
+        public T[] Data
+        {
+            get { return data; }
+        }
+
+        ImmutableList()
+        {
+            data = new T[0];
+        }
+
+        public ImmutableList(T[] data)
+        {
+            this.data = data;
+        }
+
+        public ImmutableList<T> Add(T value)
+        {
+            var newData = new T[data.Length + 1];
+            Array.Copy(data, newData, data.Length);
+            newData[data.Length] = value;
+            return new ImmutableList<T>(newData);
+        }
+
+        public ImmutableList<T> Remove(T value)
+        {
+            var i = IndexOf(value);
+            if (i < 0) return this;
+
+            var length = data.Length;
+            if (length == 1) return Empty;
+
+            var newData = new T[length - 1];
+
+            Array.Copy(data, 0, newData, 0, i);
+            Array.Copy(data, i + 1, newData, i, length - i - 1);
+
+            return new ImmutableList<T>(newData);
+        }
+
+        public int IndexOf(T value)
+        {
+            for (var i = 0; i < data.Length; ++i)
+            {
+                if (object.Equals(data[i], value)) return i;
+            }
+            return -1;
+        }
+    }
+}

--- a/Source/ReactiveProperty.Portable-NET45+WINRT+WP8/ReactiveProperty.Portable.csproj
+++ b/Source/ReactiveProperty.Portable-NET45+WINRT+WP8/ReactiveProperty.Portable.csproj
@@ -82,6 +82,7 @@
     <Compile Include="Notifiers\BooleanNotifier.cs" />
     <Compile Include="Notifiers\BusyNotifier.cs" />
     <Compile Include="Notifiers\CountNotifier.cs" />
+    <Compile Include="Notifiers\MessageBroker.cs" />
     <Compile Include="Notifiers\ScheduledNotifier.cs" />
     <Compile Include="ObservableEx.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/Test/ReactiveProperty.Tests/Notifiers/MessageBrokerTest.cs
+++ b/Test/ReactiveProperty.Tests/Notifiers/MessageBrokerTest.cs
@@ -1,0 +1,65 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Reactive.Bindings.Notifiers;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ReactiveProperty.Tests.Notifiers
+{
+    [TestClass]
+    public class MessageBrokerTest
+    {
+        [TestMethod]
+        public void Sync()
+        {
+            var mb = new MessageBroker();
+            var l = new List<string>();
+
+            var d1 = mb.Subscribe<int>(x => l.Add("a:" + x));
+            var d2 = mb.Subscribe<int>(x => l.Add("b:" + x));
+            var d3 = mb.ToObservable<int>().Subscribe(x => l.Add("c:" + x));
+
+            mb.Publish(100);
+            l.Is("a:100", "b:100", "c:100"); l.Clear();
+
+            d2.Dispose();
+            mb.Publish(200);
+            l.Is("a:200", "c:200"); l.Clear();
+
+            d3.Dispose();
+            mb.Publish(300);
+            l.Is("a:300"); l.Clear();
+
+            d1.Dispose();
+            mb.Publish(400);
+            l.Count.Is(0);
+        }
+
+#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
+
+        [TestMethod]
+        public async Task Async()
+        {
+            var mb = new AsyncMessageBroker();
+            var l = new List<string>();
+
+            var d1 = mb.Subscribe<int>(async x => l.Add("a:" + x));
+            var d2 = mb.Subscribe<int>(async x => l.Add("b:" + x));
+
+            await mb.PublishAsync(100);
+            l.Is("a:100", "b:100"); l.Clear();
+
+            d2.Dispose();
+            await mb.PublishAsync(200);
+            l.Is("a:200"); l.Clear();
+
+            d1.Dispose();
+            await mb.PublishAsync(300);
+            l.Count.Is(0);
+        }
+
+#pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
+    }
+}

--- a/Test/ReactiveProperty.Tests/ReactiveProperty.Tests.csproj
+++ b/Test/ReactiveProperty.Tests/ReactiveProperty.Tests.csproj
@@ -164,6 +164,7 @@
     <Compile Include="Helpers\FilteredReadOnlyObservableCollectionTest.cs" />
     <Compile Include="Init.cs" />
     <Compile Include="Interactivity\EventToReactiveTest.cs" />
+    <Compile Include="Notifiers\MessageBrokerTest.cs" />
     <Compile Include="Notifiers\BusyNotifierTest.cs" />
     <Compile Include="Notifiers\ScheduledNotifierTest.cs" />
     <Compile Include="Notifiers\BooleanNotifierTest.cs" />


### PR DESCRIPTION
I suggest new notifier called `MessageBroker`, in-memory pubsub.
This is Rx and async friendly `EventAggregator` or `MessageBus` or etc.
We can use this for messenger pattern.

If reviewer accept this code, please add to all platforms.

Sample Code:
```csharp
using Reactive.Bindings.Notifiers;
using System;
using System.Reactive.Linq;
using System.Threading.Tasks;

public class MyClass
{
    public int MyProperty { get; set; }

    public override string ToString()
    {
        return "MP:" + MyProperty;
    }
}
class Program
{
    static void RunMessageBroker()
    {
        // global scope pub-sub messaging
        MessageBroker.Default.Subscribe<MyClass>(x =>
        {
            Console.WriteLine("A:" + x);
        });

        var d = MessageBroker.Default.Subscribe<MyClass>(x =>
        {
            Console.WriteLine("B:" + x);
        });

        // support convert to IObservable<T>
        MessageBroker.Default.ToObservable<MyClass>().Subscribe(x =>
        {
            Console.WriteLine("C:" + x);
        });

        MessageBroker.Default.Publish(new MyClass { MyProperty = 100 });
        MessageBroker.Default.Publish(new MyClass { MyProperty = 200 });
        MessageBroker.Default.Publish(new MyClass { MyProperty = 300 });

        d.Dispose(); // unsubscribe
        MessageBroker.Default.Publish(new MyClass { MyProperty = 400 });
    }

    static async Task RunAsyncMessageBroker()
    {
        // asynchronous message pub-sub
        AsyncMessageBroker.Default.Subscribe<MyClass>(async x =>
        {
            Console.WriteLine("A:" + x);
            await Task.Delay(TimeSpan.FromSeconds(1));
        });

        var d = AsyncMessageBroker.Default.Subscribe<MyClass>(async x =>
        {
            Console.WriteLine("B:" + x);
            await Task.Delay(TimeSpan.FromSeconds(2));
        });

        // await all subscriber complete
        await AsyncMessageBroker.Default.PublishAsync(new MyClass { MyProperty = 100 });
        await AsyncMessageBroker.Default.PublishAsync(new MyClass { MyProperty = 200 });
        await AsyncMessageBroker.Default.PublishAsync(new MyClass { MyProperty = 300 });

        d.Dispose(); // unsubscribe
        await AsyncMessageBroker.Default.PublishAsync(new MyClass { MyProperty = 400 });
    }

    static void Main(string[] args)
    {
        Console.WriteLine("MessageBroker");
        RunMessageBroker();

        Console.WriteLine("AsyncMessageBroker");
        RunAsyncMessageBroker().Wait();
    }
}
```

messenger pattern's multi thread dispatch can handle easily by Rx.

```csharp
MessageBroker.Default.ToObservable<MyClass>()
    .ObserveOn(Dispatcher) // Rx Magic!
    .Subscribe(x =>
    {
        Console.WriteLine(x);
    });
```