### PR TITLE
[Proposal]use ImmedieateScheduler as default for ConsoleApp scenario

### DIFF
--- a/Source/ReactiveProperty.Portable-NET45+WINRT+WP8/ReactivePropertyScheduler.cs
+++ b/Source/ReactiveProperty.Portable-NET45+WINRT+WP8/ReactivePropertyScheduler.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Reactive.Concurrency;
+using System.Threading;
 
 namespace Reactive.Bindings
 {
@@ -8,12 +9,32 @@ namespace Reactive.Bindings
     /// </summary>
     public static class ReactivePropertyScheduler
     {
-        private static IScheduler DefaultScheduler { get; set; }
+        static IScheduler defaultScheduler;
 
         /// <summary>
         /// Get ReactiveProperty default scheduler.
         /// </summary>
-        public static IScheduler Default => DefaultScheduler ?? UIDispatcherScheduler.Default;
+        public static IScheduler Default
+        {
+            get
+            {
+                if (defaultScheduler != null)
+                {
+                    return defaultScheduler;
+                }
+                if (UIDispatcherScheduler.IsSchedulerCreated)
+                {
+                    return UIDispatcherScheduler.Default;
+                }
+
+                if (SynchronizationContext.Current == null)
+                {
+                    return ImmediateScheduler.Instance;
+                }
+
+                return UIDispatcherScheduler.Default;
+            }
+        }
 
         /// <summary>
         /// set default scheduler.
@@ -21,7 +42,7 @@ namespace Reactive.Bindings
         /// <param name="defaultScheduler"></param>
         public static void SetDefault(IScheduler defaultScheduler)
         {
-            DefaultScheduler = defaultScheduler;
+            ReactivePropertyScheduler.defaultScheduler = defaultScheduler;
         }
     }
 }

--- a/Source/ReactiveProperty.Portable-NET45+WINRT+WP8/UIDispatcherScheduler.cs
+++ b/Source/ReactiveProperty.Portable-NET45+WINRT+WP8/UIDispatcherScheduler.cs
@@ -27,7 +27,9 @@ namespace Reactive.Bindings
         /// <para>UIDIspatcherScheduler is created when access to UIDispatcher.Default first in the whole application.</para>
         /// <para>If you want to explicitly initialize, call UIDispatcherScheduler.Initialize() in App.xaml.cs.</para>
         /// </summary>
-        public static IScheduler Default => DefaultScheduler.Value; 
+        public static IScheduler Default => DefaultScheduler.Value;
+
+        internal static bool IsSchedulerCreated = DefaultScheduler.IsValueCreated;
 
         /// <summary>
         /// Create UIDispatcherSchedule on called thread if is not initialized yet.


### PR DESCRIPTION
If we use ReactiveProperty in Console Application or LINQPad or etc, RxProp throws exception from Scheduler.
We should set default scheduler explicitly.

This pull request is proposal to use Console Application scenario.
`ReactivePropertyScheduler.Default` returns `ImmediateScheduler` when `UIDispatcherScheduler` is not created and `SynchronizationContext.Current` is null.