### PR TITLE
Expose ReactiveProeprty's settings for serialization

### DIFF
--- a/Source/ReactiveProperty.Portable/ReactiveProperty.cs
+++ b/Source/ReactiveProperty.Portable/ReactiveProperty.cs
@@ -42,9 +42,9 @@ namespace Reactive.Bindings
 
         private T LatestValue { get; set; }
         private bool IsDisposed { get; set; } = false;
-        private IScheduler RaiseEventScheduler { get; }
-        private bool IsDistinctUntilChanged { get; }
-        private bool IsRaiseLatestValueOnSubscribe { get; }
+        public IScheduler RaiseEventScheduler { get; }
+        public bool IsDistinctUntilChanged { get; }
+        public bool IsRaiseLatestValueOnSubscribe { get; }
 
         private Subject<T> Source { get; } = new Subject<T>();
         private IDisposable SourceDisposable { get; }


### PR DESCRIPTION
I'm trying `ReactiveProperty<T>` as serializable.
It is useful to restore state, used from serialize ViewModel.

Ofcourse subscriptions can not serialize but value is possible.

ReactiveProperty needs three states to deserialize.
`LatestValue` and `ReactivePropertyMode` and `RaiseEventScheduler`.

If ReactiveProperty expose there properties, external serializer's type resolver can it.