### PR TITLE
fix iOS SetBinding build issue

### DIFF
--- a/Source/ReactiveProperty.Platform.iOS/BindingSupportExtensions.cs
+++ b/Source/ReactiveProperty.Platform.iOS/BindingSupportExtensions.cs
@@ -1,0 +1,40 @@
+using Reactive.Bindings.Extensions;
+using Reactive.Bindings.Internal;
+using System;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reactive;
+using System.Reactive.Disposables;
+using System.Reactive.Linq;
+using UIKit;
+
+namespace Reactive.Bindings
+{
+    public static class BindingSupportExtensions
+    {
+        /// <summary>
+        /// Command binding method.
+        /// </summary>
+        /// <typeparam name="T">Command type.</typeparam>
+        /// <param name="self">IObservable</param>
+        /// <param name="command">Command</param>
+        /// <returns>Command binding token</returns>
+        public static IDisposable SetCommand<T>(this IObservable<T> self, ReactiveCommand<T> command) =>
+            self
+                .Where(_ => command.CanExecute())
+                .Subscribe(x => command.Execute(x));
+
+        /// <summary>
+        /// Command binding method.
+        /// </summary>
+        /// <typeparam name="T">IObservable type</typeparam>
+        /// <param name="self">IObservable</param>
+        /// <param name="command">Command</param>
+        /// <returns>Command binding token</returns>
+        public static IDisposable SetCommand<T>(this IObservable<T> self, ReactiveCommand command) =>
+            self
+                .Where(_ => command.CanExecute())
+                .Subscribe(x => command.Execute());
+
+    }
+}

--- a/Source/ReactiveProperty.Platform.iOS/IUITableViewDataSourceExtensions.cs
+++ b/Source/ReactiveProperty.Platform.iOS/IUITableViewDataSourceExtensions.cs
@@ -22,7 +22,7 @@ namespace Reactive.Bindings
         /// <param name="source">Source property</param>
         /// <param name="updateSourceTrigger">Update source trigger</param>
         /// <returns>Data binding token</returns>
-        public static IDisposable SetBinding<TView, TProperty>(
+        public static IDisposable SetBindingTableViewDataSource<TView, TProperty>(
             this TView self,
             Expression<Func<TView, TProperty>> propertySelector,
             ReactiveProperty<TProperty> source, Func<TView, IObservable<Unit>> updateSourceTrigger = null)
@@ -68,7 +68,7 @@ namespace Reactive.Bindings
         /// <param name="source">Source property</param>
         /// <param name="updateSourceTrigger">Update source trigger</param>
         /// <returns>Data binding token</returns>
-        public static IDisposable SetBinding<TView, TProperty>(
+        public static IDisposable SetBindingTableViewDataSource<TView, TProperty>(
             this TView self,
             Action<TView, TProperty> setter,
             Func<TView, TProperty> getter,
@@ -111,13 +111,13 @@ namespace Reactive.Bindings
         /// <param name="setter">Target value setter</param>
         /// <param name="source">Source property</param>
         /// <returns>Data binding token</returns>
-        public static IDisposable SetBinding<TView, TProperty>(
+        public static IDisposable SetBindingTableViewDataSource<TView, TProperty>(
             this TView self,
             Action<TView, TProperty> setter,
             ReactiveProperty<TProperty> source)
             where TView : IUITableViewDataSource
         {
-            return SetBinding(self, setter, null, source, null);
+            return SetBindingTableViewDataSource(self, setter, null, source, null);
         }
 
         /// <summary>
@@ -129,7 +129,7 @@ namespace Reactive.Bindings
         /// <param name="propertySelector">Target property selector</param>
         /// <param name="source">Source property</param>
         /// <returns>Data binding token</returns>
-        public static IDisposable SetBinding<TView, TProperty>(
+        public static IDisposable SetBindingTableViewDataSource<TView, TProperty>(
             this TView self,
             Expression<Func<TView, TProperty>> propertySelector,
             ReadOnlyReactiveProperty<TProperty> source)
@@ -155,7 +155,7 @@ namespace Reactive.Bindings
         /// <param name="setter">Target value setter</param>
         /// <param name="source">Source property</param>
         /// <returns>Data binding token</returns>
-        public static IDisposable SetBinding<TView, TProperty>(
+        public static IDisposable SetBindingTableViewDataSource<TView, TProperty>(
             this TView self,
             Action<TView, TProperty> setter,
             ReadOnlyReactiveProperty<TProperty> source)

--- a/Source/ReactiveProperty.Platform.iOS/ReactiveProperty.Platform.iOS.csproj
+++ b/Source/ReactiveProperty.Platform.iOS/ReactiveProperty.Platform.iOS.csproj
@@ -46,6 +46,7 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="BindingSupportExtensions.cs" />
     <Compile Include="Internal\AccessorCache.cs" />
     <Compile Include="IUICollectionViewDataSourceExtensions.cs" />
     <Compile Include="IUITableViewDataSourceExtensions.cs" />

--- a/Source/ReactiveProperty.Platform.iOS/ReactiveProperty.Platform.iOS.csproj
+++ b/Source/ReactiveProperty.Platform.iOS/ReactiveProperty.Platform.iOS.csproj
@@ -46,13 +46,15 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="BindingSupportExtensions.cs" />
     <Compile Include="Internal\AccessorCache.cs" />
     <Compile Include="IUICollectionViewDataSourceExtensions.cs" />
     <Compile Include="IUITableViewDataSourceExtensions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="UIBarItemExtensions.cs" />
+    <Compile Include="UICollectionViewSourceExtensions.cs" />
+    <Compile Include="UIGestureRecognizerExtensions.cs" />
     <Compile Include="UIResponderExtensions.cs" />
+    <Compile Include="UITableViewSourceExtensions.cs" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/Source/ReactiveProperty.Platform.iOS/UIBarItemExtensions.cs
+++ b/Source/ReactiveProperty.Platform.iOS/UIBarItemExtensions.cs
@@ -22,7 +22,7 @@ namespace Reactive.Bindings
         /// <param name="source">Source property</param>
         /// <param name="updateSourceTrigger">Update source trigger</param>
         /// <returns>Data binding token</returns>
-        public static IDisposable SetBinding<TView, TProperty>(
+        public static IDisposable SetBindingBarItem<TView, TProperty>(
             this TView self,
             Expression<Func<TView, TProperty>> propertySelector,
             ReactiveProperty<TProperty> source, Func<TView, IObservable<Unit>> updateSourceTrigger = null)
@@ -68,7 +68,7 @@ namespace Reactive.Bindings
         /// <param name="source">Source property</param>
         /// <param name="updateSourceTrigger">Update source trigger</param>
         /// <returns>Data binding token</returns>
-        public static IDisposable SetBinding<TView, TProperty>(
+        public static IDisposable SetBindingBarItem<TView, TProperty>(
             this TView self,
             Action<TView, TProperty> setter,
             Func<TView, TProperty> getter,
@@ -111,13 +111,13 @@ namespace Reactive.Bindings
         /// <param name="setter">Target value setter</param>
         /// <param name="source">Source property</param>
         /// <returns>Data binding token</returns>
-        public static IDisposable SetBinding<TView, TProperty>(
+        public static IDisposable SetBindingBarItem<TView, TProperty>(
             this TView self,
             Action<TView, TProperty> setter,
             ReactiveProperty<TProperty> source)
             where TView : UIBarItem
         {
-            return SetBinding(self, setter, null, source, null);
+            return SetBindingBarItem(self, setter, null, source, null);
         }
 
         /// <summary>
@@ -129,7 +129,7 @@ namespace Reactive.Bindings
         /// <param name="propertySelector">Target property selector</param>
         /// <param name="source">Source property</param>
         /// <returns>Data binding token</returns>
-        public static IDisposable SetBinding<TView, TProperty>(
+        public static IDisposable SetBindingBarItem<TView, TProperty>(
             this TView self,
             Expression<Func<TView, TProperty>> propertySelector,
             ReadOnlyReactiveProperty<TProperty> source)
@@ -155,7 +155,7 @@ namespace Reactive.Bindings
         /// <param name="setter">Target value setter</param>
         /// <param name="source">Source property</param>
         /// <returns>Data binding token</returns>
-        public static IDisposable SetBinding<TView, TProperty>(
+        public static IDisposable SetBindingBarItem<TView, TProperty>(
             this TView self,
             Action<TView, TProperty> setter,
             ReadOnlyReactiveProperty<TProperty> source)

--- a/Source/ReactiveProperty.Platform.iOS/UICollectionViewSourceExtensions.cs
+++ b/Source/ReactiveProperty.Platform.iOS/UICollectionViewSourceExtensions.cs
@@ -1,6 +1,7 @@
-using Reactive.Bindings.Extensions;
+﻿using Reactive.Bindings.Extensions;
 using Reactive.Bindings.Internal;
 using System;
+using System.Linq;
 using System.Linq.Expressions;
 using System.Reactive;
 using System.Reactive.Disposables;
@@ -9,7 +10,7 @@ using UIKit;
 
 namespace Reactive.Bindings
 {
-    public static class BindingSupportExtensions
+    public static class UICollectionViewSourceExtensions
     {
         /// <summary>
         /// Data binding method.
@@ -21,11 +22,11 @@ namespace Reactive.Bindings
         /// <param name="source">Source property</param>
         /// <param name="updateSourceTrigger">Update source trigger</param>
         /// <returns>Data binding token</returns>
-        public static IDisposable SetBinding<TView, TProperty>(
+        public static IDisposable SetBindingCollectionViewSource<TView, TProperty>(
             this TView self,
             Expression<Func<TView, TProperty>> propertySelector,
             ReactiveProperty<TProperty> source, Func<TView, IObservable<Unit>> updateSourceTrigger = null)
-            where TView : UIView
+            where TView : UICollectionViewSource
         {
             var d = new CompositeDisposable();
 
@@ -67,13 +68,13 @@ namespace Reactive.Bindings
         /// <param name="source">Source property</param>
         /// <param name="updateSourceTrigger">Update source trigger</param>
         /// <returns>Data binding token</returns>
-        public static IDisposable SetBinding<TView, TProperty>(
+        public static IDisposable SetBindingCollectionViewSource<TView, TProperty>(
             this TView self,
             Action<TView, TProperty> setter,
             Func<TView, TProperty> getter,
-            ReactiveProperty<TProperty> source, 
+            ReactiveProperty<TProperty> source,
             Func<TView, IObservable<Unit>> updateSourceTrigger)
-            where TView : UIView
+            where TView : UICollectionViewSource
         {
             var d = new CompositeDisposable();
 
@@ -110,13 +111,13 @@ namespace Reactive.Bindings
         /// <param name="setter">Target value setter</param>
         /// <param name="source">Source property</param>
         /// <returns>Data binding token</returns>
-        public static IDisposable SetBinding<TView, TProperty>(
+        public static IDisposable SetBindingCollectionViewSource<TView, TProperty>(
             this TView self,
             Action<TView, TProperty> setter,
             ReactiveProperty<TProperty> source)
-            where TView : UIView
+            where TView : UICollectionViewSource
         {
-            return SetBinding(self, setter, null, source, null);
+            return SetBindingCollectionViewSource(self, setter, null, source, null);
         }
 
         /// <summary>
@@ -128,11 +129,11 @@ namespace Reactive.Bindings
         /// <param name="propertySelector">Target property selector</param>
         /// <param name="source">Source property</param>
         /// <returns>Data binding token</returns>
-        public static IDisposable SetBinding<TView, TProperty>(
+        public static IDisposable SetBindingCollectionViewSource<TView, TProperty>(
             this TView self,
             Expression<Func<TView, TProperty>> propertySelector,
             ReadOnlyReactiveProperty<TProperty> source)
-            where TView : UIView
+            where TView : UICollectionViewSource
         {
             var d = new CompositeDisposable();
 
@@ -154,11 +155,11 @@ namespace Reactive.Bindings
         /// <param name="setter">Target value setter</param>
         /// <param name="source">Source property</param>
         /// <returns>Data binding token</returns>
-        public static IDisposable SetBinding<TView, TProperty>(
+        public static IDisposable SetBindingCollectionViewSource<TView, TProperty>(
             this TView self,
             Action<TView, TProperty> setter,
             ReadOnlyReactiveProperty<TProperty> source)
-            where TView : UIView
+            where TView : UICollectionViewSource
         {
             var d = new CompositeDisposable();
 
@@ -168,30 +169,6 @@ namespace Reactive.Bindings
 
             return d;
         }
-
-        /// <summary>
-        /// Command binding method.
-        /// </summary>
-        /// <typeparam name="T">Command type.</typeparam>
-        /// <param name="self">IObservable</param>
-        /// <param name="command">Command</param>
-        /// <returns>Command binding token</returns>
-        public static IDisposable SetCommand<T>(this IObservable<T> self, ReactiveCommand<T> command) =>
-            self
-                .Where(_ => command.CanExecute())
-                .Subscribe(x => command.Execute(x));
-
-        /// <summary>
-        /// Command binding method.
-        /// </summary>
-        /// <typeparam name="T">IObservable type</typeparam>
-        /// <param name="self">IObservable</param>
-        /// <param name="command">Command</param>
-        /// <returns>Command binding token</returns>
-        public static IDisposable SetCommand<T>(this IObservable<T> self, ReactiveCommand command) =>
-            self
-                .Where(_ => command.CanExecute())
-                .Subscribe(x => command.Execute());
 
     }
 }

--- a/Source/ReactiveProperty.Platform.iOS/UIGestureRecognizerExtensions.cs
+++ b/Source/ReactiveProperty.Platform.iOS/UIGestureRecognizerExtensions.cs
@@ -1,4 +1,4 @@
-using Reactive.Bindings.Extensions;
+﻿using Reactive.Bindings.Extensions;
 using Reactive.Bindings.Internal;
 using System;
 using System.Linq;
@@ -10,7 +10,7 @@ using UIKit;
 
 namespace Reactive.Bindings
 {
-    public static class IUICollectionViewDataSourceExtensions
+    public static class UIGestureRecognizerExtensions
     {
         /// <summary>
         /// Data binding method.
@@ -22,11 +22,11 @@ namespace Reactive.Bindings
         /// <param name="source">Source property</param>
         /// <param name="updateSourceTrigger">Update source trigger</param>
         /// <returns>Data binding token</returns>
-        public static IDisposable SetBindingCollectionViewDataSource<TView, TProperty>(
+        public static IDisposable SetBindingGestureRecognizer<TView, TProperty>(
             this TView self,
             Expression<Func<TView, TProperty>> propertySelector,
             ReactiveProperty<TProperty> source, Func<TView, IObservable<Unit>> updateSourceTrigger = null)
-            where TView : IUICollectionViewDataSource
+            where TView : UIGestureRecognizer
         {
             var d = new CompositeDisposable();
 
@@ -68,13 +68,13 @@ namespace Reactive.Bindings
         /// <param name="source">Source property</param>
         /// <param name="updateSourceTrigger">Update source trigger</param>
         /// <returns>Data binding token</returns>
-        public static IDisposable SetBindingCollectionViewDataSource<TView, TProperty>(
+        public static IDisposable SetBindingGestureRecognizer<TView, TProperty>(
             this TView self,
             Action<TView, TProperty> setter,
             Func<TView, TProperty> getter,
             ReactiveProperty<TProperty> source,
             Func<TView, IObservable<Unit>> updateSourceTrigger)
-            where TView : IUICollectionViewDataSource
+            where TView : UIGestureRecognizer
         {
             var d = new CompositeDisposable();
 
@@ -111,13 +111,13 @@ namespace Reactive.Bindings
         /// <param name="setter">Target value setter</param>
         /// <param name="source">Source property</param>
         /// <returns>Data binding token</returns>
-        public static IDisposable SetBindingCollectionViewDataSource<TView, TProperty>(
+        public static IDisposable SetBindingGestureRecognizer<TView, TProperty>(
             this TView self,
             Action<TView, TProperty> setter,
             ReactiveProperty<TProperty> source)
-            where TView : IUICollectionViewDataSource
+            where TView : UIGestureRecognizer
         {
-            return SetBindingCollectionViewDataSource(self, setter, null, source, null);
+            return SetBindingGestureRecognizer(self, setter, null, source, null);
         }
 
         /// <summary>
@@ -129,11 +129,11 @@ namespace Reactive.Bindings
         /// <param name="propertySelector">Target property selector</param>
         /// <param name="source">Source property</param>
         /// <returns>Data binding token</returns>
-        public static IDisposable SetBindingCollectionViewDataSource<TView, TProperty>(
+        public static IDisposable SetBindingGestureRecognizer<TView, TProperty>(
             this TView self,
             Expression<Func<TView, TProperty>> propertySelector,
             ReadOnlyReactiveProperty<TProperty> source)
-            where TView : IUICollectionViewDataSource
+            where TView : UIGestureRecognizer
         {
             var d = new CompositeDisposable();
 
@@ -155,11 +155,11 @@ namespace Reactive.Bindings
         /// <param name="setter">Target value setter</param>
         /// <param name="source">Source property</param>
         /// <returns>Data binding token</returns>
-        public static IDisposable SetBindingCollectionViewDataSource<TView, TProperty>(
+        public static IDisposable SetBindingGestureRecognizer<TView, TProperty>(
             this TView self,
             Action<TView, TProperty> setter,
             ReadOnlyReactiveProperty<TProperty> source)
-            where TView : IUICollectionViewDataSource
+            where TView : UIGestureRecognizer
         {
             var d = new CompositeDisposable();
 

--- a/Source/ReactiveProperty.Platform.iOS/UITableViewSourceExtensions.cs
+++ b/Source/ReactiveProperty.Platform.iOS/UITableViewSourceExtensions.cs
@@ -1,4 +1,4 @@
-using Reactive.Bindings.Extensions;
+﻿using Reactive.Bindings.Extensions;
 using Reactive.Bindings.Internal;
 using System;
 using System.Linq;
@@ -10,7 +10,7 @@ using UIKit;
 
 namespace Reactive.Bindings
 {
-    public static class IUICollectionViewDataSourceExtensions
+    public static class UITableViewSourceExtensions
     {
         /// <summary>
         /// Data binding method.
@@ -22,11 +22,11 @@ namespace Reactive.Bindings
         /// <param name="source">Source property</param>
         /// <param name="updateSourceTrigger">Update source trigger</param>
         /// <returns>Data binding token</returns>
-        public static IDisposable SetBindingCollectionViewDataSource<TView, TProperty>(
+        public static IDisposable SetBindingTableViewSource<TView, TProperty>(
             this TView self,
             Expression<Func<TView, TProperty>> propertySelector,
             ReactiveProperty<TProperty> source, Func<TView, IObservable<Unit>> updateSourceTrigger = null)
-            where TView : IUICollectionViewDataSource
+            where TView : UITableViewSource
         {
             var d = new CompositeDisposable();
 
@@ -68,13 +68,13 @@ namespace Reactive.Bindings
         /// <param name="source">Source property</param>
         /// <param name="updateSourceTrigger">Update source trigger</param>
         /// <returns>Data binding token</returns>
-        public static IDisposable SetBindingCollectionViewDataSource<TView, TProperty>(
+        public static IDisposable SetBindingTableViewSource<TView, TProperty>(
             this TView self,
             Action<TView, TProperty> setter,
             Func<TView, TProperty> getter,
             ReactiveProperty<TProperty> source,
             Func<TView, IObservable<Unit>> updateSourceTrigger)
-            where TView : IUICollectionViewDataSource
+            where TView : UITableViewSource
         {
             var d = new CompositeDisposable();
 
@@ -111,13 +111,13 @@ namespace Reactive.Bindings
         /// <param name="setter">Target value setter</param>
         /// <param name="source">Source property</param>
         /// <returns>Data binding token</returns>
-        public static IDisposable SetBindingCollectionViewDataSource<TView, TProperty>(
+        public static IDisposable SetBindingTableViewSource<TView, TProperty>(
             this TView self,
             Action<TView, TProperty> setter,
             ReactiveProperty<TProperty> source)
-            where TView : IUICollectionViewDataSource
+            where TView : UITableViewSource
         {
-            return SetBindingCollectionViewDataSource(self, setter, null, source, null);
+            return SetBindingTableViewSource(self, setter, null, source, null);
         }
 
         /// <summary>
@@ -129,11 +129,11 @@ namespace Reactive.Bindings
         /// <param name="propertySelector">Target property selector</param>
         /// <param name="source">Source property</param>
         /// <returns>Data binding token</returns>
-        public static IDisposable SetBindingCollectionViewDataSource<TView, TProperty>(
+        public static IDisposable SetBindingTableViewSource<TView, TProperty>(
             this TView self,
             Expression<Func<TView, TProperty>> propertySelector,
             ReadOnlyReactiveProperty<TProperty> source)
-            where TView : IUICollectionViewDataSource
+            where TView : UITableViewSource
         {
             var d = new CompositeDisposable();
 
@@ -155,11 +155,11 @@ namespace Reactive.Bindings
         /// <param name="setter">Target value setter</param>
         /// <param name="source">Source property</param>
         /// <returns>Data binding token</returns>
-        public static IDisposable SetBindingCollectionViewDataSource<TView, TProperty>(
+        public static IDisposable SetBindingTableViewSource<TView, TProperty>(
             this TView self,
             Action<TView, TProperty> setter,
             ReadOnlyReactiveProperty<TProperty> source)
-            where TView : IUICollectionViewDataSource
+            where TView : UITableViewSource
         {
             var d = new CompositeDisposable();
 


### PR DESCRIPTION
`SetBinding<TView, TProperty>(...) where TView : (anything)` methods cause CS0121 build error in Xamarin.iOS.

```
Error CS0121: The call is ambiguous between the following methods or properties: 
`Reactive.Bindings.BindingSupportExtensions.SetBinding<UIKit.UITextField,string>(this UIKit.UITextField, System.Linq.Expressions.Expression<System.Func<UIKit.UITextField,string>>, Reactive.Bindings.ReactiveProperty<string>, System.Func<UIKit.UITextField,System.IObservable<System.Reactive.Unit>>)' and 
`Reactive.Bindings.IUICollectionViewDataSourceExtensions.SetBinding<UIKit.UITextField,string>(this UIKit.UITextField, System.Linq.Expressions.Expression<System.Func<UIKit.UITextField,string>>, Reactive.Bindings.ReactiveProperty<string>, System.Func<UIKit.UITextField,System.IObservable<System.Reactive.Unit>>)' (CS0121)
```

This PR fix iOS SetBinding method build issue by rename SetBinding methods and improve UIKit binding supports.

- Rename `SetBinding` methods to `SetBinding+(type)` (expect UIResponder)
- Remove extension methods for UIView.
    - Because UIResponder(superclass) has it.
- Add UITableViewSource, UICollectionViewSource and UIGestureRecognizer extension methods.