### PR TITLE
Add ReactivePropertySlim, ReadOnlyReactivePropertySlim

### DIFF
--- a/Source/ReactiveProperty.NETStandard/ReactivePropertySlim.cs
+++ b/Source/ReactiveProperty.NETStandard/ReactivePropertySlim.cs
@@ -114,7 +114,7 @@ namespace Reactive.Bindings
         bool IsDistinctUntilChanged => (mode & ReactivePropertyMode.DistinctUntilChanged) == ReactivePropertyMode.DistinctUntilChanged;
         bool IsRaiseLatestValueOnSubscribe => (mode & ReactivePropertyMode.RaiseLatestValueOnSubscribe) == ReactivePropertyMode.RaiseLatestValueOnSubscribe;
 
-        public ReactivePropertySlim(T initialValue = default(T), ReactivePropertyMode mode = ReactivePropertyMode.DistinctUntilChanged | ReactivePropertyMode.RaiseLatestValueOnSubscribe, EqualityComparer<T> equalityComparer = null)
+        public ReactivePropertySlim(T initialValue = default(T), ReactivePropertyMode mode = ReactivePropertyMode.DistinctUntilChanged | ReactivePropertyMode.RaiseLatestValueOnSubscribe, IEqualityComparer<T> equalityComparer = null)
         {
             this.latestValue = initialValue;
             this.mode = mode;
@@ -274,7 +274,7 @@ namespace Reactive.Bindings
         bool IsDistinctUntilChanged => (mode & ReactivePropertyMode.DistinctUntilChanged) == ReactivePropertyMode.DistinctUntilChanged;
         bool IsRaiseLatestValueOnSubscribe => (mode & ReactivePropertyMode.RaiseLatestValueOnSubscribe) == ReactivePropertyMode.RaiseLatestValueOnSubscribe;
 
-        public ReadOnlyReactivePropertySlim(IObservable<T> source, T initialValue = default(T), ReactivePropertyMode mode = ReactivePropertyMode.DistinctUntilChanged | ReactivePropertyMode.RaiseLatestValueOnSubscribe, EqualityComparer<T> equalityComparer = null)
+        public ReadOnlyReactivePropertySlim(IObservable<T> source, T initialValue = default(T), ReactivePropertyMode mode = ReactivePropertyMode.DistinctUntilChanged | ReactivePropertyMode.RaiseLatestValueOnSubscribe, IEqualityComparer<T> equalityComparer = null)
         {
             this.latestValue = initialValue;
             this.mode = mode;
@@ -394,7 +394,7 @@ namespace Reactive.Bindings
 
     public static class ReadOnlyReactivePropertySlim
     {
-        public static ReadOnlyReactivePropertySlim<T> ToReadOnlyReactivePropertySlim<T>(this IObservable<T> source, T initialValue = default(T), ReactivePropertyMode mode = ReactivePropertyMode.DistinctUntilChanged | ReactivePropertyMode.RaiseLatestValueOnSubscribe, EqualityComparer<T> equalityComparer = null)
+        public static ReadOnlyReactivePropertySlim<T> ToReadOnlyReactivePropertySlim<T>(this IObservable<T> source, T initialValue = default(T), ReactivePropertyMode mode = ReactivePropertyMode.DistinctUntilChanged | ReactivePropertyMode.RaiseLatestValueOnSubscribe, IEqualityComparer<T> equalityComparer = null)
         {
             return new ReadOnlyReactivePropertySlim<T>(source, initialValue, mode, equalityComparer);
         }

--- a/Source/ReactiveProperty.NETStandard/ReactivePropertySlim.cs
+++ b/Source/ReactiveProperty.NETStandard/ReactivePropertySlim.cs
@@ -251,7 +251,6 @@ namespace Reactive.Bindings
         ObserverNode<T> last;
 
         public event PropertyChangedEventHandler PropertyChanged;
-        public event EventHandler<DataErrorsChangedEventArgs> ErrorsChanged;
 
         public T Value
         {

--- a/Source/ReactiveProperty.NETStandard/ReactivePropertySlim.cs
+++ b/Source/ReactiveProperty.NETStandard/ReactivePropertySlim.cs
@@ -203,6 +203,13 @@ namespace Reactive.Bindings
             }
         }
 
+        public override string ToString()
+        {
+            return (latestValue == null)
+                ? "null"
+                : latestValue.ToString();
+        }
+
         // NotSupported validation.
 
         bool INotifyDataErrorInfo.HasErrors => throw new NotSupportedException();
@@ -375,6 +382,13 @@ namespace Reactive.Bindings
         {
             // oncompleted same as dispose.
             Dispose();
+        }
+
+        public override string ToString()
+        {
+            return (latestValue == null)
+                ? "null"
+                : latestValue.ToString();
         }
     }
 

--- a/Source/ReactiveProperty.NETStandard/ReactivePropertySlim.cs
+++ b/Source/ReactiveProperty.NETStandard/ReactivePropertySlim.cs
@@ -1,0 +1,388 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Reactive.Disposables;
+using System.Threading;
+
+namespace Reactive.Bindings
+{
+    // This file includes ReactivePropertySlim and ReadOnlyReactivePropertySlim.
+
+    internal interface IObserverLinkedList<T>
+    {
+        void UnsubscribeNode(ObserverNode<T> node);
+    }
+
+    internal sealed class ObserverNode<T> : IObserver<T>, IDisposable
+    {
+        readonly IObserver<T> observer;
+        IObserverLinkedList<T> list;
+
+        public ObserverNode<T> Previous { get; internal set; }
+        public ObserverNode<T> Next { get; internal set; }
+
+        public ObserverNode(IObserverLinkedList<T> list, IObserver<T> observer)
+        {
+            this.list = list;
+            this.observer = observer;
+        }
+
+        public void OnNext(T value)
+        {
+            observer.OnNext(value);
+        }
+
+        public void OnError(Exception error)
+        {
+            observer.OnError(error);
+        }
+
+        public void OnCompleted()
+        {
+            observer.OnCompleted();
+        }
+
+        public void Dispose()
+        {
+            var sourceList = Interlocked.Exchange(ref list, null);
+            if (sourceList != null)
+            {
+                sourceList.UnsubscribeNode(this);
+                sourceList = null;
+            }
+        }
+    }
+
+    public class ReactivePropertySlim<T> : IReactiveProperty<T>, IReadOnlyReactiveProperty<T>, IObserverLinkedList<T>
+    {
+        const int IsDisposedFlagNumber = 1 << 9; // (reserve 0 ~ 8)
+
+        // minimize field count
+        T latestValue;
+        ReactivePropertyMode mode; // None = 0, DistinctUntilChanged = 1, RaiseLatestValueOnSubscribe = 2, Disposed = (1 << 9)
+        readonly EqualityComparer<T> equalityComparer;
+        ObserverNode<T> root;
+        ObserverNode<T> last;
+
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        public T Value
+        {
+            get
+            {
+                return latestValue;
+            }
+            set
+            {
+                if (IsDistinctUntilChanged && equalityComparer.Equals(latestValue, value))
+                {
+                    return;
+                }
+
+                // Note:can set null and can set after disposed.
+                this.latestValue = value;
+                if (!IsDisposed)
+                {
+                    OnNextAndRaiseValueChanged(ref value);
+                }
+            }
+        }
+
+        public bool IsDisposed => (int)mode == IsDisposedFlagNumber;
+
+        object IReactiveProperty.Value
+        {
+            get
+            {
+                return (object)Value;
+            }
+            set
+            {
+                Value = (T)value;
+            }
+        }
+
+        object IReadOnlyReactiveProperty.Value
+        {
+            get
+            {
+                return (object)Value;
+            }
+        }
+
+        bool IsDistinctUntilChanged => (mode & ReactivePropertyMode.DistinctUntilChanged) == ReactivePropertyMode.DistinctUntilChanged;
+        bool IsRaiseLatestValueOnSubscribe => (mode & ReactivePropertyMode.RaiseLatestValueOnSubscribe) == ReactivePropertyMode.RaiseLatestValueOnSubscribe;
+
+        public ReactivePropertySlim(T initialValue = default(T), ReactivePropertyMode mode = ReactivePropertyMode.DistinctUntilChanged | ReactivePropertyMode.RaiseLatestValueOnSubscribe, EqualityComparer<T> equalityComparer = null)
+        {
+            this.latestValue = initialValue;
+            this.mode = mode;
+            this.equalityComparer = equalityComparer ?? EqualityComparer<T>.Default;
+        }
+
+        void OnNextAndRaiseValueChanged(ref T value)
+        {
+            // call source.OnNext
+            var node = root;
+            while (node != null)
+            {
+                node.OnNext(value);
+                node = node.Next;
+            }
+
+            this.PropertyChanged?.Invoke(this, SingletonPropertyChangedEventArgs.Value);
+        }
+
+        public void ForceNotify()
+        {
+            OnNextAndRaiseValueChanged(ref latestValue);
+        }
+
+        public IDisposable Subscribe(IObserver<T> observer)
+        {
+            if (IsDisposed)
+            {
+                observer.OnCompleted();
+                return Disposable.Empty;
+            }
+
+            if (IsRaiseLatestValueOnSubscribe)
+            {
+                observer.OnNext(this.latestValue);
+            }
+
+            // subscribe node, node as subscription.
+            var next = new ObserverNode<T>(this, observer);
+            if (root == null)
+            {
+                root = last = next;
+            }
+            else
+            {
+                last.Next = next;
+                next.Previous = last;
+                last = next;
+            }
+            return next;
+        }
+
+        void IObserverLinkedList<T>.UnsubscribeNode(ObserverNode<T> node)
+        {
+            if (node == root)
+            {
+                root = node.Next;
+            }
+            if (node == last)
+            {
+                last = node.Previous;
+            }
+
+            if (node.Previous != null)
+            {
+                node.Previous.Next = node.Next;
+            }
+            if (node.Next != null)
+            {
+                node.Next.Previous = node.Previous;
+            }
+        }
+
+        public void Dispose()
+        {
+            if (IsDisposed) return;
+
+            var node = root;
+            root = last = null;
+            mode = (ReactivePropertyMode)IsDisposedFlagNumber;
+
+            while (node != null)
+            {
+                node.OnCompleted();
+                node = node.Next;
+            }
+        }
+
+        // NotSupported validation.
+
+        bool INotifyDataErrorInfo.HasErrors => throw new NotSupportedException();
+
+        IObservable<IEnumerable> IHasErrors.ObserveErrorChanged => throw new NotSupportedException();
+
+        IObservable<bool> IHasErrors.ObserveHasErrors => throw new NotSupportedException();
+
+        event EventHandler<DataErrorsChangedEventArgs> INotifyDataErrorInfo.ErrorsChanged
+        {
+            add
+            {
+                throw new NotSupportedException();
+            }
+
+            remove
+            {
+                throw new NotSupportedException();
+            }
+        }
+
+        IEnumerable INotifyDataErrorInfo.GetErrors(string propertyName)
+        {
+            throw new NotSupportedException();
+        }
+    }
+
+    public class ReadOnlyReactivePropertySlim<T> : IReadOnlyReactiveProperty<T>, IObserverLinkedList<T>, IObserver<T>
+    {
+        const int IsDisposedFlagNumber = 1 << 9; // (reserve 0 ~ 8)
+
+        // minimize field count
+        T latestValue;
+        IDisposable sourceSubscription;
+        ReactivePropertyMode mode; // None = 0, DistinctUntilChanged = 1, RaiseLatestValueOnSubscribe = 2, Disposed = (1 << 9)
+        readonly EqualityComparer<T> equalityComparer;
+
+        ObserverNode<T> root;
+        ObserverNode<T> last;
+
+        public event PropertyChangedEventHandler PropertyChanged;
+        public event EventHandler<DataErrorsChangedEventArgs> ErrorsChanged;
+
+        public T Value
+        {
+            get
+            {
+                return latestValue;
+            }
+        }
+
+        public bool IsDisposed => (int)mode == IsDisposedFlagNumber;
+
+        object IReadOnlyReactiveProperty.Value
+        {
+            get
+            {
+                return (object)Value;
+            }
+        }
+
+        bool IsDistinctUntilChanged => (mode & ReactivePropertyMode.DistinctUntilChanged) == ReactivePropertyMode.DistinctUntilChanged;
+        bool IsRaiseLatestValueOnSubscribe => (mode & ReactivePropertyMode.RaiseLatestValueOnSubscribe) == ReactivePropertyMode.RaiseLatestValueOnSubscribe;
+
+        public ReadOnlyReactivePropertySlim(IObservable<T> source, T initialValue = default(T), ReactivePropertyMode mode = ReactivePropertyMode.DistinctUntilChanged | ReactivePropertyMode.RaiseLatestValueOnSubscribe, EqualityComparer<T> equalityComparer = null)
+        {
+            this.latestValue = initialValue;
+            this.mode = mode;
+            this.equalityComparer = equalityComparer ?? EqualityComparer<T>.Default;
+            this.sourceSubscription = source.Subscribe(this);
+        }
+
+        public IDisposable Subscribe(IObserver<T> observer)
+        {
+            if (IsDisposed)
+            {
+                observer.OnCompleted();
+                return Disposable.Empty;
+            }
+
+            if (IsRaiseLatestValueOnSubscribe)
+            {
+                observer.OnNext(latestValue);
+            }
+
+            // subscribe node, node as subscription.
+            var next = new ObserverNode<T>(this, observer);
+            if (root == null)
+            {
+                root = last = next;
+            }
+            else
+            {
+                last.Next = next;
+                next.Previous = last;
+                last = next;
+            }
+
+            return next;
+        }
+
+        void IObserverLinkedList<T>.UnsubscribeNode(ObserverNode<T> node)
+        {
+            if (node == root)
+            {
+                root = node.Next;
+            }
+            if (node == last)
+            {
+                last = node.Previous;
+            }
+
+            if (node.Previous != null)
+            {
+                node.Previous.Next = node.Next;
+            }
+            if (node.Next != null)
+            {
+                node.Next.Previous = node.Previous;
+            }
+        }
+
+        public void Dispose()
+        {
+            if (IsDisposed) return;
+
+            var node = root;
+            root = last = null;
+            mode = (ReactivePropertyMode)IsDisposedFlagNumber;
+
+            while (node != null)
+            {
+                node.OnCompleted();
+                node = node.Next;
+            }
+            sourceSubscription.Dispose();
+            sourceSubscription = null;
+        }
+
+        void IObserver<T>.OnNext(T value)
+        {
+            if (IsDisposed) return;
+
+            if (IsDistinctUntilChanged && equalityComparer.Equals(latestValue, value))
+            {
+                return;
+            }
+
+            // SetValue
+            this.latestValue = value;
+
+            // call source.OnNext
+            var node = root;
+            while (node != null)
+            {
+                node.OnNext(value);
+                node = node.Next;
+            }
+
+            // Notify changed.
+            this.PropertyChanged?.Invoke(this, SingletonPropertyChangedEventArgs.Value);
+        }
+
+        void IObserver<T>.OnError(Exception error)
+        {
+            // do nothing.
+        }
+
+        void IObserver<T>.OnCompleted()
+        {
+            // oncompleted same as dispose.
+            Dispose();
+        }
+    }
+
+    public static class ReadOnlyReactivePropertySlim
+    {
+        public static ReadOnlyReactivePropertySlim<T> ToReadOnlyReactivePropertySlim<T>(this IObservable<T> source, T initialValue = default(T), ReactivePropertyMode mode = ReactivePropertyMode.DistinctUntilChanged | ReactivePropertyMode.RaiseLatestValueOnSubscribe, EqualityComparer<T> equalityComparer = null)
+        {
+            return new ReadOnlyReactivePropertySlim<T>(source, initialValue, mode, equalityComparer);
+        }
+    }
+}

--- a/Source/ReactiveProperty.NETStandard/ReactivePropertySlim.cs
+++ b/Source/ReactiveProperty.NETStandard/ReactivePropertySlim.cs
@@ -61,7 +61,7 @@ namespace Reactive.Bindings
         // minimize field count
         T latestValue;
         ReactivePropertyMode mode; // None = 0, DistinctUntilChanged = 1, RaiseLatestValueOnSubscribe = 2, Disposed = (1 << 9)
-        readonly EqualityComparer<T> equalityComparer;
+        readonly IEqualityComparer<T> equalityComparer;
         ObserverNode<T> root;
         ObserverNode<T> last;
 
@@ -245,7 +245,7 @@ namespace Reactive.Bindings
         T latestValue;
         IDisposable sourceSubscription;
         ReactivePropertyMode mode; // None = 0, DistinctUntilChanged = 1, RaiseLatestValueOnSubscribe = 2, Disposed = (1 << 9)
-        readonly EqualityComparer<T> equalityComparer;
+        readonly IEqualityComparer<T> equalityComparer;
 
         ObserverNode<T> root;
         ObserverNode<T> last;

--- a/Test/ReactiveProperty.Tests/ReactiveProperty.Tests.csproj
+++ b/Test/ReactiveProperty.Tests/ReactiveProperty.Tests.csproj
@@ -12,7 +12,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>ReactiveProperty.Tests</RootNamespace>
     <AssemblyName>ReactiveProperty.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <IsWebBootstrapper>false</IsWebBootstrapper>
@@ -209,11 +209,13 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Notifiers\CountNotifierTest.cs" />
     <Compile Include="ReactiveCommandTest.cs" />
+    <Compile Include="ReactivePropertySlimTest.cs" />
     <Compile Include="ReactivePropertyTest.cs" />
     <Compile Include="ReactiveTimerTest.cs" />
     <Compile Include="ReactivePropertyTest.Static.cs" />
     <Compile Include="ReactivePropertyValidationTest.cs" />
     <Compile Include="ReadOnlyReactiveCollectionTest.cs" />
+    <Compile Include="ReadOnlyReactivePropertySlimTest.cs" />
     <Compile Include="ReadOnlyReactivePropertyTest.cs" />
     <Compile Include="ReactivePropertyPerformanceTest.cs" />
     <Compile Include="AsyncReactiveCommandTest.cs" />

--- a/Test/ReactiveProperty.Tests/ReactivePropertySlimTest.cs
+++ b/Test/ReactiveProperty.Tests/ReactivePropertySlimTest.cs
@@ -1,0 +1,120 @@
+﻿using Reactive.Bindings;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Reactive;
+using System.Reactive.Linq;
+using System.Threading.Tasks;
+using System.Reactive.Subjects;
+
+namespace ReactiveProperty.Tests
+{
+    [TestClass]
+    public class ReactivePropertySlimTest
+    {
+        [TestMethod]
+        public void NormalCase()
+        {
+            var rp = new ReactivePropertySlim<string>();
+            rp.Value.IsNull();
+            rp.Subscribe(x => x.IsNull());
+        }
+
+        [TestMethod]
+        public void InitialValue()
+        {
+            var rp = new ReactivePropertySlim<string>("Hello world");
+            rp.Value.Is("Hello world");
+            rp.Subscribe(x => x.Is("Hello world"));
+        }
+
+        [TestMethod]
+        public void NoRaiseLatestValueOnSubscribe()
+        {
+            var rp = new ReactivePropertySlim<string>(mode: ReactivePropertyMode.DistinctUntilChanged);
+            var called = false;
+            rp.Subscribe(_ => called = true);
+            called.Is(false);
+        }
+
+        [TestMethod]
+        public void NoDistinctUntilChanged()
+        {
+            var rp = new ReactivePropertySlim<string>(mode: ReactivePropertyMode.RaiseLatestValueOnSubscribe);
+            var list = new List<string>();
+            rp.Subscribe(list.Add);
+            rp.Value = "Hello world";
+            rp.Value = "Hello world";
+            rp.Value = "Hello japan";
+            list.Is(null, "Hello world", "Hello world", "Hello japan");
+        }
+
+        [TestMethod]
+        public void EnumCase()
+        {
+            var rp = new ReactivePropertySlim<TestEnum>();
+            var results = new List<TestEnum>();
+            rp.Subscribe(results.Add);
+            results.Is(TestEnum.None);
+
+            rp.Value = TestEnum.Enum1;
+            results.Is(TestEnum.None, TestEnum.Enum1);
+
+            rp.Value = TestEnum.Enum2;
+            results.Is(TestEnum.None, TestEnum.Enum1, TestEnum.Enum2);
+        }
+
+        [TestMethod]
+        public void ForceNotify()
+        {
+            var rp = new ReactivePropertySlim<int>(0);
+            var collecter = new List<int>();
+            rp.Subscribe(collecter.Add);
+
+            collecter.Is(0);
+            rp.ForceNotify();
+            collecter.Is(0, 0);
+        }
+
+        [TestMethod]
+        public void UnsubscribeTest()
+        {
+            var rp = new ReactivePropertySlim<int>(mode: ReactivePropertyMode.None);
+            var collecter = new List<(string, int)>();
+            var a = rp.Select(x => ("a", x)).Subscribe(collecter.Add);
+            var b = rp.Select(x => ("b", x)).Subscribe(collecter.Add);
+            var c = rp.Select(x => ("c", x)).Subscribe(collecter.Add);
+
+            rp.Value = 99;
+            collecter.Is(("a", 99), ("b", 99), ("c", 99));
+
+            collecter.Clear();
+            a.Dispose();
+
+            rp.Value = 40;
+            collecter.Is(("b", 40), ("c", 40));
+
+            collecter.Clear();
+            c.Dispose();
+
+            rp.Value = 50;
+            collecter.Is(("b", 50));
+
+            collecter.Clear();
+            b.Dispose();
+
+            rp.Value = 9999;
+            collecter.Count.Is(0);
+
+            var d = rp.Select(x => ("d", x)).Subscribe(collecter.Add);
+
+            rp.Value = 9;
+            collecter.Is(("d", 9));
+
+            rp.Dispose();
+        }
+    }
+}

--- a/Test/ReactiveProperty.Tests/ReadOnlyReactivePropertySlimTest.cs
+++ b/Test/ReactiveProperty.Tests/ReadOnlyReactivePropertySlimTest.cs
@@ -1,0 +1,200 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Reactive.Bindings;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive.Concurrency;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using System.Reactive.Disposables;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ReactiveProperty.Tests
+{
+    [TestClass]
+    public class ReadOnlyReactivePropertySlimTest
+    {
+        [TestMethod]
+        public void NormalPattern()
+        {
+            var s = new Subject<string>();
+
+            var rp = s.ToReadOnlyReactivePropertySlim();
+            var buffer = new List<string>();
+            rp.Subscribe(buffer.Add);
+
+            rp.Value.IsNull();
+            buffer.Count.Is(1);
+            buffer[0].IsNull();
+
+            s.OnNext("Hello");
+            rp.Value.Is("Hello");
+            buffer.Count.Is(2);
+            buffer.Is(default(string), "Hello");
+
+            s.OnNext("Hello");
+            rp.Value.Is("Hello");
+            buffer.Count.Is(2); // distinct until changed.
+        }
+
+        [TestMethod]
+        public void MultiSubscribeTest()
+        {
+            var s = new Subject<string>();
+
+            var rp = s.ToReadOnlyReactivePropertySlim();
+            var buffer1 = new List<string>();
+            rp.Subscribe(buffer1.Add);
+
+
+            buffer1.Count.Is(1);
+            s.OnNext("Hello world");
+            buffer1.Count.Is(2);
+            buffer1.Is(default(string), "Hello world");
+
+            var buffer2 = new List<string>();
+            rp.Subscribe(buffer2.Add);
+            buffer1.Is(default(string), "Hello world");
+            buffer2.Is("Hello world");
+
+            s.OnNext("ReactiveProperty");
+            buffer1.Is(default(string), "Hello world", "ReactiveProperty");
+            buffer2.Is("Hello world", "ReactiveProperty");
+        }
+
+        [TestMethod]
+        public void NormalPatternNoDistinctUntilChanged()
+        {
+            var s = new Subject<string>();
+
+            var rp = s.ToReadOnlyReactivePropertySlim(
+                mode: ReactivePropertyMode.RaiseLatestValueOnSubscribe);
+            var buffer = new List<string>();
+            rp.Subscribe(buffer.Add);
+
+            rp.Value.IsNull();
+            buffer.Count.Is(1);
+            buffer[0].IsNull();
+
+            s.OnNext("Hello");
+            rp.Value.Is("Hello");
+            buffer.Count.Is(2);
+            buffer.Is(default(string), "Hello");
+
+            s.OnNext("Hello");
+            rp.Value.Is("Hello");
+            buffer.Count.Is(3); // not distinct until changed.
+        }
+
+        [TestMethod]
+        public void PropertyChangedTest()
+        {
+            var s = new Subject<string>();
+            var rp = s.ToReadOnlyReactivePropertySlim();
+            var buffer = new List<string>();
+            rp.PropertyChanged += (_, args) =>
+            {
+                buffer.Add(args.PropertyName);
+            };
+
+            buffer.Count.Is(0);
+
+            s.OnNext("Hello");
+            buffer.Count.Is(1);
+
+            s.OnNext("Hello");
+            buffer.Count.Is(1);
+
+            s.OnNext("World");
+            buffer.Count.Is(2);
+        }
+
+        [TestMethod]
+        public void PropertyChangedNoDistinctUntilChangedTest()
+        {
+            var s = new Subject<string>();
+            var rp = s.ToReadOnlyReactivePropertySlim(
+                mode: ReactivePropertyMode.RaiseLatestValueOnSubscribe);
+            var buffer = new List<string>();
+            rp.PropertyChanged += (_, args) =>
+            {
+                buffer.Add(args.PropertyName);
+            };
+
+            buffer.Count.Is(0);
+
+            s.OnNext("Hello");
+            buffer.Count.Is(1);
+
+            s.OnNext("Hello");
+            buffer.Count.Is(2);
+
+            s.OnNext("World");
+            buffer.Count.Is(3);
+        }
+
+        [TestMethod]
+        public void BehaviorSubjectTest()
+        {
+            var s = new BehaviorSubject<string>("initial value");
+            var rp = s.ToReadOnlyReactivePropertySlim();
+            rp.Value.Is("initial value");
+        }
+
+        [TestMethod]
+        public void ObservableCreateTest()
+        {
+            var i = 0;
+            var s = Observable.Create<int>(ox =>
+            {
+                i++;
+                return Disposable.Empty;
+            });
+
+            i.Is(0);
+            var rp = s.ToReadOnlyReactivePropertySlim();
+            i.Is(1);
+        }
+
+        [TestMethod]
+        public void UnsubscribeTest()
+        {
+            var source = new ReactivePropertySlim<int>(mode: ReactivePropertyMode.None);
+            var rp = source.ToReadOnlyReactivePropertySlim(mode: ReactivePropertyMode.None);
+
+            var collecter = new List<(string, int)>();
+            var a = rp.Select(x => ("a", x)).Subscribe(collecter.Add);
+            var b = rp.Select(x => ("b", x)).Subscribe(collecter.Add);
+            var c = rp.Select(x => ("c", x)).Subscribe(collecter.Add);
+
+            source.Value = 99;
+            collecter.Is(("a", 99), ("b", 99), ("c", 99));
+
+            collecter.Clear();
+            a.Dispose();
+
+            source.Value = 40;
+            collecter.Is(("b", 40), ("c", 40));
+
+            collecter.Clear();
+            c.Dispose();
+
+            source.Value = 50;
+            collecter.Is(("b", 50));
+
+            collecter.Clear();
+            b.Dispose();
+
+            source.Value = 9999;
+            collecter.Count.Is(0);
+
+            var d = rp.Select(x => ("d", x)).Subscribe(collecter.Add);
+
+            source.Value = 9;
+            collecter.Is(("d", 9));
+
+            rp.Dispose();
+        }
+    }
+}

--- a/Test/ReactiveProperty.Tests/app.config
+++ b/Test/ReactiveProperty.Tests/app.config
@@ -1,35 +1,35 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="System.Reactive.Interfaces" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.2.5.0" newVersion="2.2.5.0" />
+        <assemblyIdentity name="System.Reactive.Interfaces" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-2.2.5.0" newVersion="2.2.5.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Reactive.Core" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.2.5.0" newVersion="2.2.5.0" />
+        <assemblyIdentity name="System.Reactive.Core" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-2.2.5.0" newVersion="2.2.5.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Reactive.Linq" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.2.5.0" newVersion="2.2.5.0" />
+        <assemblyIdentity name="System.Reactive.Linq" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-2.2.5.0" newVersion="2.2.5.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Reactive.Core" publicKeyToken="94bc3704cddfc263" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-3.0.3000.0" newVersion="3.0.3000.0" />
+        <assemblyIdentity name="System.Reactive.Core" publicKeyToken="94bc3704cddfc263" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-3.0.3000.0" newVersion="3.0.3000.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Reactive.Interfaces" publicKeyToken="94bc3704cddfc263" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-3.0.1000.0" newVersion="3.0.1000.0" />
+        <assemblyIdentity name="System.Reactive.Interfaces" publicKeyToken="94bc3704cddfc263" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-3.0.1000.0" newVersion="3.0.1000.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Reactive.Linq" publicKeyToken="94bc3704cddfc263" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-3.0.1000.0" newVersion="3.0.1000.0" />
+        <assemblyIdentity name="System.Reactive.Linq" publicKeyToken="94bc3704cddfc263" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-3.0.1000.0" newVersion="3.0.1000.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Runtime.Serialization.Primitives" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.1.2.0" newVersion="4.1.2.0" />
+        <assemblyIdentity name="System.Runtime.Serialization.Primitives" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.1.2.0" newVersion="4.1.2.0"/>
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2" /></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7"/></startup></configuration>

--- a/Test/ReactiveProperty.Tests/packages.config
+++ b/Test/ReactiveProperty.Tests/packages.config
@@ -21,8 +21,8 @@
   <package id="System.Globalization" version="4.3.0" targetFramework="net45" />
   <package id="System.IO" version="4.3.0" targetFramework="net45" requireReinstallation="true" />
   <package id="System.IO.Compression" version="4.3.0" targetFramework="net45" requireReinstallation="true" />
-  <package id="System.Linq" version="4.3.0" targetFramework="net45" />
-  <package id="System.Linq.Expressions" version="4.3.0" targetFramework="net45" />
+  <package id="System.Linq" version="4.3.0" targetFramework="net45" requireReinstallation="true" />
+  <package id="System.Linq.Expressions" version="4.3.0" targetFramework="net45" requireReinstallation="true" />
   <package id="System.Net.Http" version="4.3.3" targetFramework="net462" />
   <package id="System.Net.Primitives" version="4.3.0" targetFramework="net45" />
   <package id="System.ObjectModel" version="4.3.0" targetFramework="net45" />
@@ -44,13 +44,13 @@
   <package id="System.Runtime.Numerics" version="4.3.0" targetFramework="net45" />
   <package id="System.Runtime.Serialization.Primitives" version="4.3.0" targetFramework="net462" />
   <package id="System.Runtime.Serialization.Xml" version="4.3.0" targetFramework="net462" />
-  <package id="System.Security.Cryptography.Algorithms" version="4.3.1" targetFramework="net462" />
+  <package id="System.Security.Cryptography.Algorithms" version="4.3.1" targetFramework="net462" requireReinstallation="true" />
   <package id="System.Security.Cryptography.Encoding" version="4.3.0" targetFramework="net462" />
   <package id="System.Security.Cryptography.Primitives" version="4.3.0" targetFramework="net462" />
   <package id="System.Security.Cryptography.X509Certificates" version="4.3.2" targetFramework="net462" />
   <package id="System.Text.Encoding" version="4.3.0" targetFramework="net45" />
   <package id="System.Text.Encoding.Extensions" version="4.3.0" targetFramework="net45" />
-  <package id="System.Text.RegularExpressions" version="4.3.0" targetFramework="net45" />
+  <package id="System.Text.RegularExpressions" version="4.3.0" targetFramework="net45" requireReinstallation="true" />
   <package id="System.Threading" version="4.3.0" targetFramework="net45" />
   <package id="System.Threading.Tasks" version="4.3.0" targetFramework="net45" />
   <package id="System.Xml.ReaderWriter" version="4.3.1" targetFramework="net462" />


### PR DESCRIPTION
Sometimes ReactiveProperty is used in Model(not ViewModel)
but ReactiveProperty is mainly designed for ViewModel
so it is too heavy to use in Model.

I've added `ReactivePropertySlim<T>` and `ReadOnlyReactivePropertySlim<T>`.
There are...

* Minimize allocation, it allocates only four small field(latestValue, observernode, mode).
* Not allocate subject and subscription, ReactiveProperty itself is publisher and subscription itself is linkedlist node.
* Not use scheduler(UIDispatcherScheduler), it is overhead and causes annoying behaviour.
* Not implement validation methods.
* ReactivePropertySlim does not implement from observable source(from source should only use ReadOnlyReactiveProperty).

This implementation achieves huge performance improvement.
Of course ReactivePropertySlim can also use in ViewModel.