### PR TITLE
Improve BindingSupportExtensions for Xamarin.Android

### DIFF
--- a/Source/ReactiveProperty.Platform.Android/BindingSupportExtensions.cs
+++ b/Source/ReactiveProperty.Platform.Android/BindingSupportExtensions.cs
@@ -24,7 +24,7 @@ namespace Reactive.Bindings
         public static IDisposable SetBinding<TView, TProperty>(
             this TView self,
             Expression<Func<TView, TProperty>> propertySelector,
-            ReactiveProperty<TProperty> source, Func<TView, IObservable<Unit>> updateSourceTrigger = null)
+            IReactiveProperty<TProperty> source, Func<TView, IObservable<Unit>> updateSourceTrigger = null)
             where TView : View
         {
             var d = new CompositeDisposable();
@@ -68,7 +68,7 @@ namespace Reactive.Bindings
         public static IDisposable SetBinding<TView, TProperty>(
             this TView self,
             Expression<Func<TView, TProperty>> propertySelector,
-            ReadOnlyReactiveProperty<TProperty> source)
+            IReadOnlyReactiveProperty<TProperty> source)
             where TView : View
         {
             var d = new CompositeDisposable();

--- a/Source/ReactiveProperty.Platform.Android/BindingSupportExtensions.cs
+++ b/Source/ReactiveProperty.Platform.Android/BindingSupportExtensions.cs
@@ -105,5 +105,29 @@ namespace Reactive.Bindings
                 .Where(_ => command.CanExecute())
                 .Subscribe(x => command.Execute());
 
+        /// <summary>
+        /// Command binding method.
+        /// </summary>
+        /// <typeparam name="T">Command type.</typeparam>
+        /// <param name="self">IObservable</param>
+        /// <param name="command">Command</param>
+        /// <returns>Command binding token</returns>
+        public static IDisposable SetCommand<T>(this IObservable<T> self, AsyncReactiveCommand<T> command) =>
+            self
+                .Where(_ => command.CanExecute())
+                .Subscribe(x => command.Execute(x));
+
+        /// <summary>
+        /// Command binding method.
+        /// </summary>
+        /// <typeparam name="T">IObservable type</typeparam>
+        /// <param name="self">IObservable</param>
+        /// <param name="command">Command</param>
+        /// <returns>Command binding token</returns>
+        public static IDisposable SetCommand<T>(this IObservable<T> self, AsyncReactiveCommand command) =>
+            self
+                .Where(_ => command.CanExecute())
+                .Subscribe(x => command.Execute());
+
     }
 }


### PR DESCRIPTION
- change to using IReactiveProperty and IReadOnlyReactiveProperty interface(for ReactivePropertySlim/ReadOnlyReactivePropertySlim)
- add SetCommand method for AsyncReactiveCommand