### PR TITLE
mode関係の読み取り専用プロパティをPublicに

### DIFF
--- a/Source/ReactiveProperty.NETStandard/ReactivePropertySlim.cs
+++ b/Source/ReactiveProperty.NETStandard/ReactivePropertySlim.cs
@@ -111,8 +111,8 @@ namespace Reactive.Bindings
             }
         }
 
-        bool IsDistinctUntilChanged => (mode & ReactivePropertyMode.DistinctUntilChanged) == ReactivePropertyMode.DistinctUntilChanged;
-        bool IsRaiseLatestValueOnSubscribe => (mode & ReactivePropertyMode.RaiseLatestValueOnSubscribe) == ReactivePropertyMode.RaiseLatestValueOnSubscribe;
+        public bool IsDistinctUntilChanged => (mode & ReactivePropertyMode.DistinctUntilChanged) == ReactivePropertyMode.DistinctUntilChanged;
+        public bool IsRaiseLatestValueOnSubscribe => (mode & ReactivePropertyMode.RaiseLatestValueOnSubscribe) == ReactivePropertyMode.RaiseLatestValueOnSubscribe;
 
         public ReactivePropertySlim(T initialValue = default(T), ReactivePropertyMode mode = ReactivePropertyMode.DistinctUntilChanged | ReactivePropertyMode.RaiseLatestValueOnSubscribe, IEqualityComparer<T> equalityComparer = null)
         {


### PR DESCRIPTION
ReactivePropertySlimをシリアライズしようとしたら、mode関係のプロパティが外から読めなかったのでPublicにしました。
読み取り専用プロパティなので特に問題は起きないはずです。