### PR TITLE
Implements IReadOnlyReactiveProperty<T> to IReactiveProperty<T>

### DIFF
--- a/Source/ReactiveProperty.NETStandard/IReactiveProperty.cs
+++ b/Source/ReactiveProperty.NETStandard/IReactiveProperty.cs
@@ -6,20 +6,20 @@ namespace Reactive.Bindings
     /// <summary>
     /// for EventToReactive and Serialization
     /// </summary>
-    public interface IReactiveProperty : IHasErrors
+    public interface IReactiveProperty : IReadOnlyReactiveProperty, IHasErrors
     {
         /// <summary>
         /// Gets or sets the value.
         /// </summary>
         /// <value>The value.</value>
-        object Value { get; set; }
+        new object Value { get; set; }
     }
 
     /// <summary>
     /// </summary>
     /// <typeparam name="T"></typeparam>
     /// <seealso cref="Reactive.Bindings.IHasErrors"/>
-    public interface IReactiveProperty<T> : IReactiveProperty, IObservable<T>, IDisposable, INotifyPropertyChanged, INotifyDataErrorInfo
+    public interface IReactiveProperty<T> : IReactiveProperty, IReadOnlyReactiveProperty<T>, IObservable<T>, IDisposable, INotifyPropertyChanged, INotifyDataErrorInfo
     {
         /// <summary>
         /// Gets or sets the value.

--- a/Source/ReactiveProperty.NETStandard/ReactiveProperty.cs
+++ b/Source/ReactiveProperty.NETStandard/ReactiveProperty.cs
@@ -59,7 +59,7 @@ namespace Reactive.Bindings
     /// Two-way bindable IObserable&lt;T&gt;
     /// </summary>
     /// <typeparam name="T"></typeparam>
-    public class ReactiveProperty<T> : IReactiveProperty<T>, IReadOnlyReactiveProperty<T>
+    public class ReactiveProperty<T> : IReactiveProperty<T>
     {
         /// <summary>
         /// Implements of INotifyPropertyChanged.

--- a/Source/ReactiveProperty.NETStandard/ReactivePropertySlim.cs
+++ b/Source/ReactiveProperty.NETStandard/ReactivePropertySlim.cs
@@ -58,7 +58,7 @@ namespace Reactive.Bindings
     /// <summary>
     /// </summary>
     /// <typeparam name="T"></typeparam>
-    public class ReactivePropertySlim<T> : IReactiveProperty<T>, IReadOnlyReactiveProperty<T>, IObserverLinkedList<T>
+    public class ReactivePropertySlim<T> : IReactiveProperty<T>, IObserverLinkedList<T>
     {
         private const int IsDisposedFlagNumber = 1 << 9; // (reserve 0 ~ 8)
 


### PR DESCRIPTION
IReactiveProperty is always convertible to IReadOnlyReactiveProperty.
This implementation is same to [UniRx](https://github.com/neuecc/UniRx).