### PR TITLE
The issue that the CollectionChanged event raised from ObservableCollection changes with ReadOnlyReactiveCollection

### DIFF
--- a/Source/ReactiveProperty.NETStandard/ReadOnlyReactiveCollection.cs
+++ b/Source/ReactiveProperty.NETStandard/ReadOnlyReactiveCollection.cs
@@ -77,8 +77,7 @@ namespace Reactive.Bindings
                 .Subscribe(x =>
                 {
                     var targetValue = Source[x.OldIndex];
-                    Source.RemoveAt(x.OldIndex);
-                    Source.Insert(x.Index, targetValue);
+                    Source.Move(x.OldIndex, x.Index);
                 })
                 .AddTo(Token);
 

--- a/Test/ReactiveProperty.NETStandard.Tests/ReadOnlyReactiveCollectionTest.cs
+++ b/Test/ReactiveProperty.NETStandard.Tests/ReadOnlyReactiveCollectionTest.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
+using System.Linq;
 using System.Reactive;
 using System.Reactive.Concurrency;
 using System.Reactive.Disposables;
@@ -231,6 +232,26 @@ namespace ReactiveProperty.Tests
             var item = c1.ToReadOnlyReactiveCollection(disposeElement: false);
             c1.Clear();
             invoked.IsFalse();
+        }
+
+        [TestMethod]
+        public void MoveCollectionChangedEventTest()
+        {
+            var records = new List<NotifyCollectionChangedEventArgs>();
+            var source = new ObservableCollection<string>();
+            var rc = source.ToReadOnlyReactiveCollection();
+            ((INotifyCollectionChanged)rc).CollectionChanged += (s, e) => records.Add(e);
+            source.Add("a");
+            source.Add("b");
+            source.Move(0, 1);
+
+            source.Is("b", "a");
+            rc.Is("b", "a");
+
+            records.Select(x => x.Action).Is(
+                NotifyCollectionChangedAction.Add,
+                NotifyCollectionChangedAction.Add,
+                NotifyCollectionChangedAction.Move);
         }
     }
 

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "3.1.301"
+    "version": "3.1.402"
   },
   "msbuild-sdks": {
     "MSBuild.Sdk.Extras": "2.0.54"


### PR DESCRIPTION
#177

## Current behavior

### Code
```csharp
var c = new ObservableCollection<string>();
var rc = c.ToReadOnlyReactiveCollection();
((INotifyCollectionChanged)rc).CollectionChanged += (_, e) =>
{
    Console.WriteLine($"{e.Action}");
};

c.Add("a");
c.Add("b");
c.Add("c");
c.Move(0, 1);
```

### Output

```
Add
Add
Add
Remove
Add
```

## Expected output

```
Add
Add
Add
Move
```
