### PR TITLE
ReactiveProperty<T> doesn't raise PropertyChanged when HasErrors changes. 

### DIFF
--- a/Source/ReactiveProperty.Core/Internals/SingletonPropertyChangedEventArgs.cs
+++ b/Source/ReactiveProperty.Core/Internals/SingletonPropertyChangedEventArgs.cs
@@ -5,5 +5,6 @@ namespace Reactive.Bindings.Internals
     internal static class SingletonPropertyChangedEventArgs
     {
         public static readonly PropertyChangedEventArgs Value = new PropertyChangedEventArgs(nameof(IReactiveProperty.Value));
+        public static readonly PropertyChangedEventArgs HasErrors = new PropertyChangedEventArgs(nameof(INotifyDataErrorInfo.HasErrors));
     }
 }

--- a/Source/ReactiveProperty.NETStandard/ReactiveProperty.cs
+++ b/Source/ReactiveProperty.NETStandard/ReactiveProperty.cs
@@ -304,11 +304,19 @@ namespace Reactive.Bindings
                 })
                 .Subscribe(x =>
                 {
+                    var prevHasErrors = HasErrors;
                     CurrentErrors = x;
+                    var currentHasErrors = HasErrors;
                     var handler = ErrorsChanged;
                     if (handler != null)
                     {
                         RaiseEventScheduler.Schedule(() => handler(this, SingletonDataErrorsChangedEventArgs.Value));
+                    }
+
+                    var propertyChangedHandler = PropertyChanged;
+                    if (prevHasErrors != currentHasErrors && propertyChangedHandler != null)
+                    {
+                        RaiseEventScheduler.Schedule(() => propertyChangedHandler(this, SingletonPropertyChangedEventArgs.HasErrors));
                     }
 
                     ErrorsTrigger.Value.OnNext(x);

--- a/Test/ReactiveProperty.NETStandard.Tests/ReactivePropertyTest.cs
+++ b/Test/ReactiveProperty.NETStandard.Tests/ReactivePropertyTest.cs
@@ -5,12 +5,14 @@ using System.Linq;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.Reactive.Testing;
 using Reactive.Bindings;
+using Reactive.Bindings.Extensions;
 
 namespace ReactiveProperty.Tests
 {
     [TestClass]
-    public class ReactivePropertyTest
+    public class ReactivePropertyTest : ReactiveTest
     {
         [TestMethod]
         public void NormalCase()
@@ -168,6 +170,20 @@ namespace ReactiveProperty.Tests
             collector.Is(0);
             rp.ForceNotify();
             collector.Is(0, 0);
+        }
+
+        [TestMethod]
+        public void RaisePropertyChangedWhenHasErrorsChanged()
+        {
+            var testScheduler = new TestScheduler();
+            var observer = testScheduler.CreateObserver<bool>();
+            var rp = new ReactiveProperty<string>("okazuki")
+                .SetValidateNotifyError(x => x.ToLower() == "error" ? "error" : null);
+            rp.ObserveProperty(x => x.HasErrors).Subscribe(observer);
+
+            rp.Value = "error";
+            rp.Value = "Error";
+            observer.Messages.Is(OnNext(0, false), OnNext(0, true));
         }
     }
 


### PR DESCRIPTION
#188