### PR TITLE
Performance improvement for FilteredReadOnlyObservableCollection

### DIFF
--- a/Source/ReactiveProperty.NETStandard/Helpers/FilteredReadOnlyObservableCollection.cs
+++ b/Source/ReactiveProperty.NETStandard/Helpers/FilteredReadOnlyObservableCollection.cs
@@ -52,11 +52,12 @@ namespace Reactive.Bindings.Helpers
 
         private List<int?> IndexList { get; } = new List<int?>();
 
-        private CompositeDisposable Subscription { get; } = new CompositeDisposable();
+        private bool IsDisposed { get; set; }
 
         private int ItemsCount { get; set; }
 
         private List<TElement> InnerCollection { get; } = new List<TElement>();
+        private Dictionary<TElement, IDisposable> PropertyChangedSubscriptions { get; } = new Dictionary<TElement, IDisposable>();
 
         /// <summary>
         /// CollectionChanged event.
@@ -73,109 +74,140 @@ namespace Reactive.Bindings.Helpers
             Source = source;
             Filter = filter;
 
-            Initialize();
+            Initialize(true);
 
+            // collection changed(support single changed only)
+            source.CollectionChanged += SourceCollectionChanged;
+        }
+
+        private void ElementPropertyChanged(object sender, PropertyChangedEventArgs e)
+        {
+            var item = (TElement)sender;
+            var index = Source.IndexOf(item);
+            var filteredIndex = IndexList[index];
+            var isTarget = Filter(item);
+            if (isTarget && filteredIndex == null)
             {
-                // propertychanged
-                source.ObserveElementPropertyChanged<TCollection, TElement>()
-                    .Subscribe(x =>
-                    {
-                        var index = source.IndexOf(x.Sender);
-                        var filteredIndex = IndexList[index];
-                        var isTarget = Filter(x.Sender);
-                        if (isTarget && filteredIndex == null)
-                        {
-                            // add
-                            AppearNewItem(index);
-                        }
-                        else if (!isTarget && filteredIndex.HasValue)
-                        {
-                            // remove
-                            DisappearItem(index);
-                            IndexList[index] = null;
-                            OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Remove, x.Sender, filteredIndex.Value));
-                        }
-                    })
-                    .AddTo(Subscription);
+                // add
+                AppearNewItem(index);
             }
+            else if (!isTarget && filteredIndex.HasValue)
             {
-                // collection changed(support single changed only)
-                source.CollectionChangedAsObservable()
-                    .Subscribe(x =>
-                    {
-                        switch (x.Action)
-                        {
-                            case NotifyCollectionChangedAction.Add:
-                                // appear
-                                IndexList.Insert(x.NewStartingIndex, null);
-                                if (Filter(x.NewItems.Cast<TElement>().Single()))
-                                {
-                                    AppearNewItem(x.NewStartingIndex);
-                                }
-                                break;
-
-                            case NotifyCollectionChangedAction.Move:
-                                throw new NotSupportedException("Move is not supported");
-                            case NotifyCollectionChangedAction.Remove:
-                                var removedIndex = IndexList[x.OldStartingIndex];
-                                if (removedIndex.HasValue)
-                                {
-                                    DisappearItem(x.OldStartingIndex);
-                                    IndexList.RemoveAt(x.OldStartingIndex);
-                                    OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Remove,
-                                        x.OldItems.Cast<TElement>().Single(), removedIndex.Value));
-                                }
-                                else
-                                {
-                                    IndexList.RemoveAt(x.OldStartingIndex);
-                                }
-                                break;
-
-                            case NotifyCollectionChangedAction.Replace:
-                                var index = IndexList[x.NewStartingIndex];
-                                var isTarget = Filter(x.NewItems.Cast<TElement>().Single());
-                                if (index == null && isTarget)
-                                {
-                                    // add
-                                    AppearNewItem(x.NewStartingIndex);
-                                }
-                                else if (index.HasValue && isTarget)
-                                {
-                                    // replace
-                                    InnerCollection[index.Value] = x.NewItems.Cast<TElement>().Single();
-                                    OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Replace,
-                                        x.NewItems.Cast<TElement>().Single(), x.OldItems.Cast<TElement>().Single(), index.Value));
-                                }
-                                else if (index.HasValue && !isTarget)
-                                {
-                                    // remove
-                                    DisappearItem(x.NewStartingIndex);
-                                    IndexList[x.NewStartingIndex] = null;
-                                    OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Remove,
-                                        x.OldItems.Cast<TElement>().Single(), index.Value));
-                                }
-
-                                break;
-
-                            case NotifyCollectionChangedAction.Reset:
-                                IndexList.Clear();
-                                InnerCollection.Clear();
-                                OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
-                                if (source.Any())
-                                {
-                                    throw new NotSupportedException("Reset is clear only");
-                                }
-                                break;
-
-                            default:
-                                throw new InvalidOperationException();
-                        }
-                    })
-                    .AddTo(Subscription);
+                // remove
+                DisappearItem(index);
+                IndexList[index] = null;
+                OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Remove, sender, filteredIndex.Value));
             }
         }
 
-        private void Initialize()
+        private void SourceCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
+        {
+            switch (e.Action)
+            {
+                case NotifyCollectionChangedAction.Add:
+                    {
+                        // appear
+                        var addedItem = e.NewItems.Cast<TElement>().Single();
+                        SubscribePropertyChanged(addedItem);
+                        IndexList.Insert(e.NewStartingIndex, null);
+                        if (Filter(addedItem))
+                        {
+                            AppearNewItem(e.NewStartingIndex);
+                        }
+                    }
+                    break;
+
+                case NotifyCollectionChangedAction.Move:
+                    throw new NotSupportedException("Move is not supported");
+                case NotifyCollectionChangedAction.Remove:
+                    {
+                        var removedItem = e.OldItems.Cast<TElement>().Single();
+                        UnsubscribePropertyChanged(removedItem);
+                        var removedIndex = IndexList[e.OldStartingIndex];
+                        if (removedIndex.HasValue)
+                        {
+                            DisappearItem(e.OldStartingIndex);
+                            IndexList.RemoveAt(e.OldStartingIndex);
+                            OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Remove,
+                                removedItem, removedIndex.Value));
+                        }
+                        else
+                        {
+                            IndexList.RemoveAt(e.OldStartingIndex);
+                        }
+                    }
+                    break;
+
+                case NotifyCollectionChangedAction.Replace:
+                    {
+                        var addedItem = e.NewItems.Cast<TElement>().Single();
+                        var removedItem = e.OldItems.Cast<TElement>().Single();
+                        SubscribePropertyChanged(addedItem);
+                        UnsubscribePropertyChanged(removedItem);
+                        var index = IndexList[e.NewStartingIndex];
+                        var isTarget = Filter(addedItem);
+                        if (index == null && isTarget)
+                        {
+                            // add
+                            AppearNewItem(e.NewStartingIndex);
+                        }
+                        else if (index.HasValue && isTarget)
+                        {
+                            // replace
+                            InnerCollection[index.Value] = addedItem;
+                            OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Replace,
+                                addedItem, removedItem, index.Value));
+                        }
+                        else if (index.HasValue && !isTarget)
+                        {
+                            // remove
+                            DisappearItem(e.NewStartingIndex);
+                            IndexList[e.NewStartingIndex] = null;
+                            OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Remove,
+                                e.OldItems.Cast<TElement>().Single(), index.Value));
+                        }
+                    }
+                    break;
+
+                case NotifyCollectionChangedAction.Reset:
+                    UnsubscribeAllPropertyChanged();
+                    IndexList.Clear();
+                    InnerCollection.Clear();
+                    OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
+                    if (Source.Any())
+                    {
+                        throw new NotSupportedException("Reset is clear only");
+                    }
+                    break;
+
+                default:
+                    throw new InvalidOperationException();
+            }
+        }
+
+        private void SubscribePropertyChanged(TElement e)
+        {
+            e.PropertyChanged += ElementPropertyChanged;
+            PropertyChangedSubscriptions.Add(e, Disposable.Create(() => e.PropertyChanged -= ElementPropertyChanged));
+        }
+
+        private void UnsubscribePropertyChanged(TElement e)
+        {
+            PropertyChangedSubscriptions[e].Dispose();
+            PropertyChangedSubscriptions.Remove(e);
+        }
+
+        private void UnsubscribeAllPropertyChanged()
+        {
+            foreach (var d in PropertyChangedSubscriptions.Values)
+            {
+                d.Dispose();
+            }
+
+            PropertyChangedSubscriptions.Clear();
+        }
+
+        private void Initialize(bool isNeedObservePropertyChanged)
         {
             IndexList.Clear();
             ItemsCount = 0;
@@ -183,6 +215,11 @@ namespace Reactive.Bindings.Helpers
 
             foreach (var item in Source)
             {
+                if (isNeedObservePropertyChanged)
+                {
+                    SubscribePropertyChanged(item);
+                }
+
                 var isTarget = Filter(item);
                 IndexList.Add(isTarget ? (int?)ItemsCount : null);
                 if (isTarget)
@@ -216,15 +253,8 @@ namespace Reactive.Bindings.Helpers
 
         object IList.this[int index]
         {
-            get
-            {
-                return InnerCollection[index];
-            }
-
-            set
-            {
-                throw new NotSupportedException();
-            }
+            get => InnerCollection[index];
+            set => throw new NotSupportedException();
         }
 
         /// <summary>
@@ -259,8 +289,9 @@ namespace Reactive.Bindings.Helpers
         /// </summary>
         public void Dispose()
         {
-            if (Subscription.IsDisposed) { return; }
-            Subscription.Dispose();
+            if (IsDisposed) { return; }
+            UnsubscribeAllPropertyChanged();
+            Source.CollectionChanged -= SourceCollectionChanged;
         }
 
         private int FindNearIndex(int position) => IndexList.Take(position).Reverse().FirstOrDefault(x => x != null) ?? -1;
@@ -326,7 +357,7 @@ namespace Reactive.Bindings.Helpers
         public void Refresh(Func<TElement, bool> filter)
         {
             Filter = filter;
-            Initialize();
+            Initialize(false);
             CollectionChanged?.Invoke(this, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
         }
     }

--- a/Source/SharedProperties.csproj
+++ b/Source/SharedProperties.csproj
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <RootNamespace>Reactive.Bindings</RootNamespace>
-    <Version>7.7.0</Version>
+    <Version>7.7.1</Version>
     <Authors>neuecc xin9le okazuki</Authors>
     <PackageProjectUrl>https://github.com/runceel/ReactiveProperty</PackageProjectUrl>
     <PackageTags>rx mvvm async rx-main reactive</PackageTags>

--- a/Source/SharedProperties.csproj
+++ b/Source/SharedProperties.csproj
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <RootNamespace>Reactive.Bindings</RootNamespace>
-    <Version>7.6.1</Version>
+    <Version>7.6.2</Version>
     <Authors>neuecc xin9le okazuki</Authors>
     <PackageProjectUrl>https://github.com/runceel/ReactiveProperty</PackageProjectUrl>
     <PackageTags>rx mvvm async rx-main reactive</PackageTags>

--- a/Test/ReactiveProperty.NETStandard.Tests/Helpers/FilteredReadOnlyObservableCollectionTest.cs
+++ b/Test/ReactiveProperty.NETStandard.Tests/Helpers/FilteredReadOnlyObservableCollectionTest.cs
@@ -355,6 +355,20 @@ namespace ReactiveProperty.Tests.Helpers
             filtered.Is(source[1], source[3]);
         }
 
+        [TestMethod]
+        [Timeout(10 * 1000)]
+        public void PerformanceTest()
+        {
+            var source = new ObservableCollection<Person>(Enumerable.Range(1, 1000000).Select(x => new Person
+            {
+                Name = $"tanaka {x}",
+                IsRemoved = x % 2 == 0,
+            }));
+
+            var filtered = source.ToFilteredReadOnlyObservableCollection(x => !x.IsRemoved);
+            filtered.Count.Is(500000);
+        }
+
         #region private class
 
         private class Person : INotifyPropertyChanged


### PR DESCRIPTION
## Issue summary

ToFilteredReadOnlyObservableCollection gets really bad performance (speed and memory usages) on UI thread.

Measured performance of creating an instance of FilteredReadOnlyObservableCollection from an ObservableCollection that has 1,000,000 items.

Time; 540 seconds
Memory usages: 1,024 MB