### PR TITLE
Fixing throwing InvalidCastException when referenceing Value property of CollectionChanged<T> of ReadOnlyReactiveCollection<T>

### DIFF
--- a/Source/ReactiveProperty.NETStandard/ReadOnlyReactiveCollection.cs
+++ b/Source/ReactiveProperty.NETStandard/ReadOnlyReactiveCollection.cs
@@ -45,12 +45,13 @@ namespace Reactive.Bindings
                 .Subscribe(x => ApplyCollectionChanged(x, static (source, args) =>
                 {
                     var index = args.Index;
-                    foreach (var item in args.Values)
+                    var values = args.Values.ToArray();
+                    foreach (var item in values)
                     {
                         source.Insert(index++, item);
                     }
 
-                    return new(NotifyCollectionChangedAction.Add, args.Values, args.Index);
+                    return new(NotifyCollectionChangedAction.Add, values, args.Index);
                 }))
                 .AddTo(Token);
 
@@ -307,7 +308,7 @@ namespace Reactive.Bindings
         /// <summary>
         /// Changed value.
         /// </summary>
-        public T Value => Values.FirstOrDefault();
+        public T Value => Values == null ? default : Values.FirstOrDefault();
 
         /// <summary>
         /// Changed index.

--- a/Test/ReactiveProperty.NETStandard.Tests/ReadOnlyReactiveCollectionTest.cs
+++ b/Test/ReactiveProperty.NETStandard.Tests/ReadOnlyReactiveCollectionTest.cs
@@ -270,11 +270,22 @@ namespace ReactiveProperty.Tests
         {
             var source = new ObservableCollection<string>();
             var target = source.ToReadOnlyReactiveCollection();
-            var values = new List<string>();
-            target.ToCollectionChanged().Subscribe(x => values.Add(x.Value));
+            var values = new List<CollectionChanged<string>>();
+            target.ToCollectionChanged().Subscribe(x => values.Add(x));
 
             source.Add("abc");
-            values.Is("abc");
+            source.Add("def");
+            source.Remove("abc");
+            source.Clear();
+            values.Is(
+                new[]
+                {
+                    CollectionChanged<string>.Add(0, "abc"),
+                    CollectionChanged<string>.Add(1, "def"),
+                    CollectionChanged<string>.Remove(0, "abc"),
+                    CollectionChanged<string>.Reset,
+                },
+                (x, y) => x.Action == y.Action && x.Value == y.Value);
         }
     }
 

--- a/Test/ReactiveProperty.NETStandard.Tests/ReadOnlyReactiveCollectionTest.cs
+++ b/Test/ReactiveProperty.NETStandard.Tests/ReadOnlyReactiveCollectionTest.cs
@@ -264,6 +264,18 @@ namespace ReactiveProperty.Tests
                 NotifyCollectionChangedAction.Add,
                 NotifyCollectionChangedAction.Move);
         }
+
+        [TestMethod]
+        public void ToCollectionChangedTest()
+        {
+            var source = new ObservableCollection<string>();
+            var target = source.ToReadOnlyReactiveCollection();
+            var values = new List<string>();
+            target.ToCollectionChanged().Subscribe(x => values.Add(x.Value));
+
+            source.Add("abc");
+            values.Is("abc");
+        }
     }
 
     internal class ConstructorCounter


### PR DESCRIPTION
Fixing throwing `InvalidCastException` when referenceing Value property of `CollectionChanged<T>` of `ReadOnlyReactiveCollection<T>`. #316