### PR TITLE
Improve blazor support

### DIFF
--- a/Samples/Blazor/BlazorSample.Shared/Pages/Index.razor
+++ b/Samples/Blazor/BlazorSample.Shared/Pages/Index.razor
@@ -6,70 +6,61 @@
 @using System.Reactive.Concurrency
 @page "/"
 @implements IDisposable
-@inject ValidationViewModel _validationViewModel
-@inject HelloWorldViewModel _helloWorldViewModel
+@inject ValidationViewModel ValidationViewModel
+@inject HelloWorldViewModel HelloWorldViewModel
 
 <h1>ReactiveProperty samples</h1>
 
 <h3>Hello world</h3>
 
-<input class="form-control" type="text" @bind="_helloWorldViewModel.Input.Value" @bind:event="oninput" />
+<input class="form-control" type="text" @bind="HelloWorldViewModel.Input.Value" @bind:event="oninput" />
 <div class="alert alert-primary">
-    @_helloWorldViewModel.Output.Value
+    @HelloWorldViewModel.Output.Value
 </div>
 
 <h3>Validation sample</h3>
 
-<EditForm Model="_validationViewModel" OnInvalidSubmit="InvalidSubmit" OnValidSubmit="ValidSubmit">
+<EditForm Model="ValidationViewModel"
+          OnInvalidSubmit="ValidationViewModel.InvalidSubmitCommand.ToEvent<EditContext>()"
+          OnValidSubmit="ValidationViewModel.SubmitCommand.ToEvent<EditContext>()">
     <ReactivePropertiesValidator />
 
     <ValidationSummary />
 
     <div class="mb-3">
         <label for="firstName">First name</label>
-        <InputText @bind-Value="_validationViewModel.FirstName.Value" class="form-control" />
-        <ValidationMessage For="() => _validationViewModel.FirstName.Value" />
+        <InputText @bind-Value="ValidationViewModel.FirstName.Value" class="form-control" />
+        <ValidationMessage For="() => ValidationViewModel.FirstName.Value" />
     </div>
     <div class="mb-3">
         <label for="firstName">Last name</label>
-        <InputText @bind-Value="_validationViewModel.LastName.Value" class="form-control" />
-        <ValidationMessage For="() => _validationViewModel.LastName.Value" />
+        <InputText @bind-Value="ValidationViewModel.LastName.Value" class="form-control" />
+        <ValidationMessage For="() => ValidationViewModel.LastName.Value" />
     </div>
 
     <div class="mb-3">
-        <span>Full name: @_validationViewModel.FullName.Value</span>
+        <span>Full name: @ValidationViewModel.FullName.Value</span>
     </div>
 
-    <button type="submit" class="btn btn-primary">Submit</button>
+    <button type="submit" class="btn btn-primary" disabled="@ValidationViewModel.SubmitCommand.IsDisabled()">Submit</button>
 </EditForm>
 
-@if (!string.IsNullOrEmpty(_message))
+@if (!string.IsNullOrEmpty(ValidationViewModel.Message.Value))
 {
     <div class="alert alert-primary">
-        <span>@_message</span>
+        <span>@ValidationViewModel.Message.Value</span>
     </div>
 }
 
 @code {
     private readonly CompositeDisposable _disposable = new();
-    private string? _message;
-
-    private void InvalidSubmit(EditContext context)
-    {
-        _message = "InvalidSubmit was invoked.";
-    }
-
-    private void ValidSubmit(EditContext context)
-    {
-        _message = "ValidSubmit was invoked.";
-    }
 
     protected override void OnInitialized()
     {
-        _validationViewModel.AddTo(_disposable);
-        _helloWorldViewModel.AddTo(_disposable);
+        ValidationViewModel.AddTo(_disposable);
+        HelloWorldViewModel.AddTo(_disposable);
 
-        _helloWorldViewModel.Output
+        HelloWorldViewModel.Output
             .Subscribe(_ => InvokeAsync(StateHasChanged))
             .AddTo(_disposable);
     }

--- a/Source/Directory.Build.props
+++ b/Source/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <RootNamespace>Reactive.Bindings</RootNamespace>
-    <Version>9.0.0</Version>
+    <Version>9.1.0</Version>
     <Authors>neuecc xin9le okazuki</Authors>
     <PackageProjectUrl>https://github.com/runceel/ReactiveProperty</PackageProjectUrl>
     <PackageTags>rx mvvm async rx-main reactive</PackageTags>

--- a/Source/ReactiveProperty.Core/ValidatableReactiveProperty.cs
+++ b/Source/ReactiveProperty.Core/ValidatableReactiveProperty.cs
@@ -257,7 +257,7 @@ public class ValidatableReactiveProperty<T> : IReactiveProperty<T>, IObserverLin
     }
 
     /// <inheritdoc/>
-    public void ForceNotify() => Validate(_latestValue);
+    public void ForceNotify() => Validate(_latestValue, ValidationKind.Force);
 
     /// <inheritdoc/>
     IEnumerable INotifyDataErrorInfo.GetErrors(string? propertyName) => _errorMessages.Value;
@@ -327,7 +327,7 @@ public class ValidatableReactiveProperty<T> : IReactiveProperty<T>, IObserverLin
         var isNotEquals = !_equalityComparer.Equals(_latestValue, value);
         var needValidation = validationKind == ValidationKind.FirstTime ? 
             !IsIgnoreInitialValidationError : 
-            isNotEquals;
+            isNotEquals || validationKind == ValidationKind.Force;
 
         _latestValue = value;
         if (needValidation)
@@ -405,6 +405,7 @@ public class ValidatableReactiveProperty<T> : IReactiveProperty<T>, IObserverLin
         Default,
         FirstTime,
         RequestFromSoucre,
+        Force,
     }
 }
 

--- a/Source/ReactiveProperty.Platform.Blazor/CommandExtensions.cs
+++ b/Source/ReactiveProperty.Platform.Blazor/CommandExtensions.cs
@@ -1,0 +1,68 @@
+﻿using System.Windows.Input;
+using Microsoft.AspNetCore.Components;
+
+namespace Reactive.Bindings;
+
+/// <summary>
+/// Command extension methods for Blazor.
+/// </summary>
+public static class CommandExtensions
+{
+    /// <summary>
+    /// Convert from ReactiveCommand to EventCallback.
+    /// </summary>
+    /// <typeparam name="TValue">The type argument of EventCallback</typeparam>
+    /// <param name="command">The command</param>
+    /// <returns>EventCallback instance</returns>
+    public static EventCallback<TValue> ToEvent<TValue>(this ReactiveCommand command) => new EventCallback<TValue>(null, (TValue _) => command.Execute());
+
+    /// <summary>
+    /// Convert from ReactiveCommand to EventCallback.
+    /// </summary>
+    /// <typeparam name="TValue">The type argument of EventCallback</typeparam>
+    /// <param name="command">The command</param>
+    /// <returns>EventCallback instance</returns>
+    public static EventCallback<TValue> ToEvent<TValue>(this ReactiveCommand<TValue> command) => new EventCallback<TValue>(null, command.Execute);
+
+    /// <summary>
+    /// Convert from ReactiveCommand to EventCallback.
+    /// </summary>
+    /// <typeparam name="TValue">The type argument of EventCallback</typeparam>
+    /// <param name="command">The command</param>
+    /// <returns>EventCallback instance</returns>
+    public static EventCallback<TValue> ToEvent<TValue>(this ReactiveCommandSlim command) => new EventCallback<TValue>(null, (TValue _) => command.Execute());
+
+    /// <summary>
+    /// Convert from ReactiveCommand to EventCallback.
+    /// </summary>
+    /// <typeparam name="TValue">The type argument of EventCallback</typeparam>
+    /// <param name="command">The command</param>
+    /// <returns>EventCallback instance</returns>
+    public static EventCallback<TValue> ToEvent<TValue>(this ReactiveCommandSlim<TValue> command) => new EventCallback<TValue>(null, command.Execute);
+
+    /// <summary>
+    /// Convert from ReactiveCommand to EventCallback.
+    /// </summary>
+    /// <typeparam name="TValue">The type argument of EventCallback</typeparam>
+    /// <param name="command">The command</param>
+    /// <returns>EventCallback instance</returns>
+    public static EventCallback<TValue> ToEvent<TValue>(this AsyncReactiveCommand command) => new EventCallback<TValue>(null, (TValue _) => command.ExecuteAsync());
+
+    /// <summary>
+    /// Convert from ReactiveCommand to EventCallback.
+    /// </summary>
+    /// <typeparam name="TValue">The type argument of EventCallback</typeparam>
+    /// <param name="command">The command</param>
+    /// <returns>EventCallback instance</returns>
+    public static EventCallback<TValue> ToEvent<TValue>(this AsyncReactiveCommand<TValue> command) => new EventCallback<TValue>(null, command.ExecuteAsync);
+
+    /// <summary>
+    /// Return a boolean value that is inverted CanExecute method.
+    /// </summary>
+    /// <param name="command">The command.</param>
+    /// <returns>Inverted value of CanExecute method.</returns>
+    public static bool IsDisabled(this ICommand command)
+    {
+        return !command.CanExecute(null);
+    }
+}

--- a/Test/ReactiveProperty.NETStandard.Tests/ValidatableReactivePropertyTest.cs
+++ b/Test/ReactiveProperty.NETStandard.Tests/ValidatableReactivePropertyTest.cs
@@ -3,6 +3,7 @@ using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Text;
 using Microsoft.Reactive.Testing;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
@@ -378,6 +379,30 @@ public class ValidatableReactivePropertyTest : ReactiveTest
             OnNext(0, true),
             OnNext(0, false),
             OnCompleted<bool>(0));
+    }
+
+    [TestMethod]
+    public void ForceNotify()
+    {
+        var target = new ValidatableReactiveProperty<string>(
+            "",
+            x => string.IsNullOrEmpty(x) ? "invalid" : null,
+            mode: ReactivePropertyMode.Default | ReactivePropertyMode.IgnoreInitialValidationError);
+
+        var testScheduler = new TestScheduler();
+        var errorChangedRecorder = testScheduler.CreateObserver<string[]>();
+        var hasErrorsRecorder = testScheduler.CreateObserver<bool>();
+        target.ObserveErrorChanged.Subscribe(errorChangedRecorder);
+        target.ObserveHasErrors.Subscribe(hasErrorsRecorder);
+
+        target.ForceNotify();
+        errorChangedRecorder.Messages.Is(
+            OnNext(0, (string[] x) => x is []),
+            OnNext(0, (string[] x) => x is ["invalid"]));
+
+        hasErrorsRecorder.Messages.Is(
+            OnNext(0, false),
+            OnNext(0, true));
     }
 
     class Person : INotifyPropertyChanged


### PR DESCRIPTION
- Fixed an issue where validation was not performed in some cases when ForceNotify was called.
- Added `ToEvent` extension method to convert from `ReactiveCommand`/`ReactiveCommandSlim`/`AsyncReactiveCommand` to `EventCallback<T>` to `ReactiveProperty.Blazor` package.
- Added `ValidatableReactiveProperty<T>` support to `ReactivePropertiesValidator` component.