### PR TITLE
Adds OnPropertyChanged to IReactiveProperty implementations

### DIFF
--- a/Source/ReactiveProperty.Core/ReactivePropertySlim.cs
+++ b/Source/ReactiveProperty.Core/ReactivePropertySlim.cs
@@ -116,6 +116,12 @@ public class ReactivePropertySlim<T> : IReactiveProperty<T>, IObserverLinkedList
         _equalityComparer = equalityComparer ?? EqualityComparer<T>.Default;
     }
 
+    /// <summary>
+    /// Used for invoking PropertyChanged event in derived classes.
+    /// </summary>
+    /// <param name="propertyName">Name of property that has changed</param>
+    protected virtual void OnPropertyChanged(string propertyName) => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+
     private void OnNextAndRaiseValueChanged(ref T value)
     {
         // call source.OnNext
@@ -290,6 +296,12 @@ public class ReadOnlyReactivePropertySlim<T> : IReadOnlyReactiveProperty<T>, IOb
     /// </summary>
     /// <value><c>true</c> if this instance is disposed; otherwise, <c>false</c>.</value>
     public bool IsDisposed => (int)_mode == IsDisposedFlagNumber;
+
+    /// <summary>
+    /// Used for invoking PropertyChanged event in derived classes.
+    /// </summary>
+    /// <param name="propertyName">Name of property that has changed</param>
+    protected virtual void OnPropertyChanged(string propertyName) => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
 
     object? IReadOnlyReactiveProperty.Value => Value;
 

--- a/Source/ReactiveProperty.Core/ValidatableReactiveProperty.cs
+++ b/Source/ReactiveProperty.Core/ValidatableReactiveProperty.cs
@@ -305,6 +305,12 @@ public class ValidatableReactiveProperty<T> : IReactiveProperty<T>, IObserverLin
         return next;
     }
 
+    /// <summary>
+    /// Used for invoking PropertyChanged event in derived classes.
+    /// </summary>
+    /// <param name="propertyName">Name of property that has changed</param>
+    protected virtual void OnPropertyChanged(string propertyName) => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+
     private void InitializeValidationProcess()
     {
         if (Source != null)

--- a/Source/ReactiveProperty.NETStandard/ReactiveProperty.cs
+++ b/Source/ReactiveProperty.NETStandard/ReactiveProperty.cs
@@ -62,6 +62,12 @@ public class ReactiveProperty<T> : IReactiveProperty<T>, IObserverLinkedList<T>
     /// </value>
     public bool IsIgnoreInitialValidationError => (_mode & ReactivePropertyMode.IgnoreInitialValidationError) == ReactivePropertyMode.IgnoreInitialValidationError;
 
+    /// <summary>
+    /// Used for invoking PropertyChanged event in derived classes.
+    /// </summary>
+    /// <param name="propertyName">Name of property that has changed</param>
+    protected virtual void OnPropertyChanged(string propertyName) => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+
     private readonly IEqualityComparer<T> _equalityComparer;
 
     private ReactivePropertyMode _mode; // None = 0, DistinctUntilChanged = 1, RaiseLatestValueOnSubscribe = 2, Disposed = (1 << 9)

--- a/Source/ReactiveProperty.NETStandard/ReadOnlyReactiveProperty.cs
+++ b/Source/ReactiveProperty.NETStandard/ReadOnlyReactiveProperty.cs
@@ -161,6 +161,12 @@ public class ReadOnlyReactiveProperty<T> : IReadOnlyReactiveProperty<T>, IObserv
         _sourceSubscription = null;
     }
 
+    /// <summary>
+    /// Used for invoking PropertyChanged event in derived classes.
+    /// </summary>
+    /// <param name="propertyName">Name of property that has changed</param>
+    protected virtual void OnPropertyChanged(string propertyName) => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+
     void IObserver<T>.OnNext(T value)
     {
         if (IsDisposed)


### PR DESCRIPTION
Adds `OnPropertyChanged` to `ReactiveProperty<T>`, `ReactivePropertySlim<T>` and `ValidateableReactiveProperty<T>` to be used in derived classes.

Related to #473 