### PR TITLE
[ReactivePropertySlim] Make it possible for a derived class to raise PropertyChanged

### DIFF
--- a/Source/ReactiveProperty.Core/ReactivePropertySlim.cs
+++ b/Source/ReactiveProperty.Core/ReactivePropertySlim.cs
@@ -246,6 +246,11 @@ public class ReactivePropertySlim<T> : IReactiveProperty<T>, IObserverLinkedList
     {
         return System.Linq.Enumerable.Empty<object>();
     }
+
+    protected virtual void OnPropertyChanged(string? propertyName = null)
+    {
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
 }
 
 /// <summary>

--- a/Source/ReactiveProperty.Core/ReactivePropertySlim.cs
+++ b/Source/ReactiveProperty.Core/ReactivePropertySlim.cs
@@ -462,6 +462,11 @@ public class ReadOnlyReactivePropertySlim<T> : IReadOnlyReactiveProperty<T>, IOb
             ? "null"
             : _latestValue.ToString();
     }
+
+    protected virtual void OnPropertyChanged(string? propertyName = null)
+    {
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
 }
 
 /// <summary>

--- a/Source/ReactiveProperty.Core/ReactivePropertySlim.cs
+++ b/Source/ReactiveProperty.Core/ReactivePropertySlim.cs
@@ -247,6 +247,7 @@ public class ReactivePropertySlim<T> : IReactiveProperty<T>, IObserverLinkedList
         return System.Linq.Enumerable.Empty<object>();
     }
 
+    // for use by derived classes
     protected virtual void OnPropertyChanged(string? propertyName = null)
     {
         PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
@@ -463,6 +464,7 @@ public class ReadOnlyReactivePropertySlim<T> : IReadOnlyReactiveProperty<T>, IOb
             : _latestValue.ToString();
     }
 
+    // for use by derived classes
     protected virtual void OnPropertyChanged(string? propertyName = null)
     {
         PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));


### PR DESCRIPTION
The reason for this change is the need for creating a convenience class for use in MAUI*. What I want to achieve is having properties `Enabled` and `Disabled` on a `ReactivePropertySlim<bool>` with change notification.

``` csharp
public sealed class ReactivePropertyBool : ReactivePropertySlim<bool>
{
    public ReactivePropertyBool(bool initialValue = default, ReactivePropertyMode mode = ReactivePropertyMode.Default)
        : base(initialValue, mode)
    {
    }

    public bool Enabled => Value;
    public bool Disabled => Value is false;

    protected override void OnPropertyChanged(string? propertyName = null)
    {
        if (propertyName == nameof(IReactiveProperty.Value))
        {
            base.OnPropertyChanged(nameof(Enabled));
            base.OnPropertyChanged(nameof(Disabled));
        }

        base.OnPropertyChanged(propertyName);
    }
}
```
\* To lessen the use of bool converters in XAML