### PR TITLE
change the timing to remove PropertyChanged event

### DIFF
--- a/Source/ReactiveProperty.Core/Internals/SimplePropertyObservable.cs
+++ b/Source/ReactiveProperty.Core/Internals/SimplePropertyObservable.cs
@@ -60,8 +60,8 @@ internal class SimplePropertyObservable<TSubject, TProperty> : IObservable<TProp
 
         private void PropertyChanged(object? sender, PropertyChangedEventArgs e)
         {
-            if (_isDisposed) throw new InvalidOperationException();
             if (e.PropertyName != _propertyName && !string.IsNullOrEmpty(e.PropertyName)) return;
+            if (_isDisposed) throw new InvalidOperationException();
 
             try
             {
@@ -80,6 +80,7 @@ internal class SimplePropertyObservable<TSubject, TProperty> : IObservable<TProp
             if (_isDisposed) return;
 
             _isDisposed = true;
+            _subject.PropertyChanged -= PropertyChanged;
             if (_onError is false)
             {
                 try
@@ -92,7 +93,6 @@ internal class SimplePropertyObservable<TSubject, TProperty> : IObservable<TProp
                 }
             }
 
-            _subject.PropertyChanged -= PropertyChanged;
             _subject = default!;
             _observer = null!;
             _accessor = null!;


### PR DESCRIPTION
いつもお世話になっております。

ReactiveProperty を 8.2.0 から 9.0.0 以降にアップデートすると、ReactivePropertySlim 周りでたまに InvalidOperationException が発生する事があるという問題が手元で起こっています。
例外の発生箇所は、SimplePropertyObservable.Subscription.PropertyChanged 関数でした。

```cs
private void PropertyChanged(object? sender, PropertyChangedEventArgs e)
{
	if (_isDisposed) throw new InvalidOperationException();
	if (e.PropertyName != _propertyName && !string.IsNullOrEmpty(e.PropertyName)) return;

	try
	{
		_observer.OnNext(_accessor(_subject));
	}
	catch (Exception ex)
	{
		_onError = true;
		_observer.OnError(ex);
		Dispose();
	}
}
```

例外発生時、確かに _isDisposed は true でした。また、e.PropertyName と _propertyName は別の名前でした。

しかし、本来、Dispose 関数が呼び出されて _isDisposed が true になっている場合、PropertyChanged イベントも remove されているはずで、PropertyChanged 関数は呼び出されないはずです。
おそらく、_isDisposed が true になってからイベントが購読解除されるまでの OnCompleted の処理中にイベントが発生してしまっていると推測します。
これをなるべく避けるために、イベントの購読解除を OnCompleted よりも先に行うように変更しました。OnCompleted の実行前に OnNext が走らないようにするのは、むしろ自然な順序かと思います。

加えて、今回起こっている問題の場合、発火されたプロパティ変更通知は Dispose された Subscription オブジェクト宛てのものではありませんでした。無関係の変更通知で例外を発生させるのは変な挙動かなと思います。
そのため、_isDisposed のチェックとプロパティ名のチェック順を逆にしました。

issue を立てずにいきなりプルリクエストを送る形になってしまいましたが、一考して頂けると幸いです。