### PR TITLE
Avoid throwing exceptions after resource disposal

### DIFF
--- a/Source/ReactiveProperty.Core/Internals/PropertyChangedObservable.cs
+++ b/Source/ReactiveProperty.Core/Internals/PropertyChangedObservable.cs
@@ -31,7 +31,7 @@ internal class PropertyChangedObservable : IObservable<PropertyChangedEventArgs>
 
         private void PropertyChanged(object? _, PropertyChangedEventArgs e)
         {
-            if (_isDisposed) throw new InvalidOperationException();
+            if (_isDisposed) return;
             _observer.OnNext(e);
         }
 

--- a/Source/ReactiveProperty.Core/Internals/PropertyPathNode.cs
+++ b/Source/ReactiveProperty.Core/Internals/PropertyPathNode.cs
@@ -113,6 +113,7 @@ internal class PropertyPathNode : IDisposable
 
     private void SourcePropertyChangedEventHandler(object? sender, PropertyChangedEventArgs e)
     {
+        if (_isDisposed) return;
         if (e.PropertyName == PropertyName || string.IsNullOrEmpty(e.PropertyName))
         {
             Next?.UpdateSource(GetPropertyValue());

--- a/Source/ReactiveProperty.Core/Internals/SimplePropertyObservable.cs
+++ b/Source/ReactiveProperty.Core/Internals/SimplePropertyObservable.cs
@@ -60,8 +60,8 @@ internal class SimplePropertyObservable<TSubject, TProperty> : IObservable<TProp
 
         private void PropertyChanged(object? sender, PropertyChangedEventArgs e)
         {
+            if (_isDisposed) return;
             if (e.PropertyName != _propertyName && !string.IsNullOrEmpty(e.PropertyName)) return;
-            if (_isDisposed) throw new InvalidOperationException();
 
             try
             {


### PR DESCRIPTION
Changed the PropertyChanged method in the PropertyChangedObservable class to return instead of throwing an InvalidOperationException when _isDisposed is true. Added a return check in the SourcePropertyChangedEventHandler method of the PropertyPathNode class when _isDisposed is true. Changed the PropertyChanged method in the SimplePropertyObservable class to return instead of throwing an InvalidOperationException when _isDisposed is true.