### PR TITLE
Add AGENTS.md, development-workflow skill, and dev-docs/ADR structure

### DIFF
--- a/.agents/skills/development-workflow/SKILL.md
+++ b/.agents/skills/development-workflow/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: development-workflow
+description: ReactiveProperty repository development policy. Use whenever you implement a feature or bug fix, change library or test code under Source/ or Test/, make a design or architecture decision, or write documentation in this repo. Enforces strict Test-Driven Development (Red -> Green -> Refactor) with MSTest and `dotnet test ReactiveProperty.slnx`, requires recording design decisions as ADRs under dev-docs/adr/, and defines the documentation split: docs/ is user-facing (published via VuePress) while dev-docs/ holds implementer/contributor documentation. Triggers include "implement", "add feature", "fix bug", "TDD", "red green refactor", "design decision", "architecture", "ADR", "where do docs go", and "contributor docs".
+---
+# Development Workflow (ReactiveProperty)
+
+The required development workflow and documentation policy for this repository.
+
+## When to Use
+- Implementing any feature or bug fix in `Source/` or `Test/`.
+- Making a design or architecture decision (public API shape, threading model, new package, dependency, breaking change).
+- Deciding where a piece of documentation belongs.
+
+## When Not to Use
+- Pure release/versioning mechanics (see `AGENTS.md` and the build/publish workflow).
+- One-off exploration or read-only investigation with no code change.
+
+---
+
+## 1. TDD is mandatory — Red → Green → Refactor
+
+Every code change to `Source/` must be driven by a failing test first. Follow the cycle
+strictly and do not skip steps:
+
+1. **Red** — Write the smallest test that expresses the desired behavior, then run it and
+   **watch it fail**. The failure must be for the right reason (asserting the new behavior,
+   not a compile error you didn't expect).
+   ```pwsh
+   dotnet test ReactiveProperty.slnx
+   ```
+   Narrow the loop while iterating, e.g. a single project or filter:
+   ```pwsh
+   dotnet test Test/ReactiveProperty.NETStandard.Tests/ReactiveProperty.NETStandard.Tests.csproj --filter "FullyQualifiedName~YourNewTest"
+   ```
+2. **Green** — Write the **minimum** production code to make the test pass. Re-run the
+   tests and confirm they are green. Don't add unrequested functionality.
+3. **Refactor** — With tests green, clean up production and test code (naming, duplication,
+   structure). Re-run tests after refactoring; they must stay green. Behavior must not change.
+
+Rules:
+- Never write production code without a failing test that requires it.
+- Keep each Red→Green→Refactor cycle small and focused on one behavior.
+- A change is not "done" until `dotnet test ReactiveProperty.slnx` passes on Windows
+  (WPF/UWP projects require Windows).
+
+### Test conventions (this repo)
+- Framework: **MSTest** (`MSTest.TestAdapter` / `MSTest.TestFramework`).
+- Helpers available: **Moq**, **Microsoft.Reactive.Testing** (`TestScheduler` for time-based
+  Rx), the bundled `ChainingAssertion` (`actual.Is(expected)` fluent assertions); Blazor
+  tests use **bunit**.
+- Put tests in the matching `Test/*` project; the core test project uses namespace
+  `ReactiveProperty.Tests`.
+- Keep new `Source/` code compatible with `netstandard2.0` / `net472` (lowest TFMs).
+
+> See the `writing-mstest-tests` and `run-tests` skills for MSTest authoring details and
+> filter/runner syntax.
+
+---
+
+## 2. Record design decisions as ADRs
+
+Going forward, every non-trivial **design / architecture decision** is recorded as an
+Architecture Decision Record (ADR).
+
+**Write an ADR when** you:
+- add or remove a public API surface, or change its semantics;
+- add a new package/project or a new external dependency;
+- change threading/scheduling, validation, or serialization behavior;
+- make a breaking change or deprecate something;
+- choose between competing implementation approaches with long-term impact.
+
+**How:**
+- ADRs live in **`dev-docs/adr/`**, one file per decision.
+- Copy `dev-docs/adr/template.md`, name it `NNNN-short-title.md` with the next zero-padded
+  number (e.g. `0002-...`), and fill in **Status, Context, Decision, Consequences**.
+- New ADRs start as `Status: Proposed`; mark `Accepted` once agreed. Don't edit accepted
+  ADRs to reverse a decision — add a new ADR that supersedes the old one and update both
+  `Status` lines.
+- Add the new ADR to the index in `dev-docs/adr/README.md`.
+
+Trivial, reversible choices (local refactors, naming) do **not** need an ADR.
+
+---
+
+## 3. Documentation split: `docs/` vs `dev-docs/`
+
+- **`docs/` = user-facing** documentation, published as the VuePress site
+  (`npm run docs:build`). Write here for library *consumers*: getting-started, API usage,
+  samples. Available in English and Japanese (`*-ja`).
+- **`dev-docs/` = implementer/contributor-facing** documentation, **not** published.
+  Write here for people working *on* ReactiveProperty: architecture notes, internal design,
+  contributor workflow, and ADRs (`dev-docs/adr/`).
+
+When you add documentation, pick the audience first:
+- "How does a consumer use this feature?" → `docs/`.
+- "How/why is this implemented, or how do I contribute?" → `dev-docs/`.
+
+---
+
+## Checklist before finishing a change
+- [ ] Behavior was driven by a failing test first (Red), then made to pass (Green), then refactored.
+- [ ] `dotnet test ReactiveProperty.slnx` passes.
+- [ ] New `Source/` code stays compatible with `netstandard2.0` / `net472`.
+- [ ] Any design/architecture decision is captured as an ADR in `dev-docs/adr/` and indexed.
+- [ ] New docs placed by audience (`docs/` for users, `dev-docs/` for implementers).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,151 @@
+# AGENTS.md
+
+Guidance for AI coding agents working in the **ReactiveProperty** repository.
+
+## What this project is
+
+ReactiveProperty provides MVVM and asynchronous support features built on top of
+Reactive Extensions (`System.Reactive`). The core type is `ReactiveProperty[Slim]<T>`,
+a value wrapper that implements `IObservable<T>` and `INotifyPropertyChanged` so it can
+flow through Rx LINQ operators and bind to XAML/Blazor UIs.
+
+- Library is consumed via NuGet packages (`ReactiveProperty`, `ReactiveProperty.Core`,
+  `ReactiveProperty.WPF`, `ReactiveProperty.Blazor`).
+- It deliberately ships **no ViewModel base class**, so it composes with other MVVM
+  frameworks (Prism, CommunityToolkit.Mvvm, etc.).
+- Note: for brand-new apps the author recommends the successor library
+  [R3](https://github.com/Cysharp/R3). This repo is in maintenance/active-support mode.
+
+> ⚠️ The root namespace is **`Reactive.Bindings`**, not `ReactiveProperty`.
+> It is set centrally in `Source/Directory.Build.props`.
+
+## Repository layout
+
+```
+Source/                         Library source (each folder is one package/assembly)
+  Directory.Build.props         Shared metadata: Version, RootNamespace, LangVersion, Nullable, SourceLink
+  ReactiveProperty.Core/        pkg ReactiveProperty.Core — minimal types, NO System.Reactive dependency
+  ReactiveProperty.NETStandard/ pkg ReactiveProperty — the main package (depends on System.Reactive)
+  ReactiveProperty.Platform.Blazor/  pkg ReactiveProperty.Blazor — EditForm validation support
+  ReactiveProperty.Platform.WPF/     pkg ReactiveProperty.WPF — EventToReactiveCommand/Property
+  ReactiveProperty.Platform.UWP/     pkg ReactiveProperty.UWP (legacy, no longer supported)
+  ReactiveProperty.Platform.Shared/  Shared project (.shproj/.projitems) imported by platform projects
+Test/                           Unit tests (MSTest)
+  ReactiveProperty.NETStandard.Tests/  Core/main library tests (namespace ReactiveProperty.Tests)
+  ReactiveProperty.Blazor.Tests/       Blazor tests (bunit)
+  ReactiveProperty.WPF.Tests/          WPF tests
+  ReactiveProperty.WPF.ManualTests/    Manual/interactive WPF test app
+Samples/                        Example apps (WPF, Blazor, MAUI-style, Prism, etc.)
+Benchmark/                      BenchmarkDotNet projects (separate solution)
+docs/                           VuePress documentation site (user-facing, published)
+dev-docs/                       Implementer/contributor docs + ADRs (not published)
+skills/                         Published agent skills for ReactiveProperty *users* (consumers)
+.agents/skills/                 Agent skills for working *on* this repo (contributors)
+Snippet/                        Visual Studio code snippets
+Directory.Packages.props        Central Package Management — all NuGet versions live here
+ReactiveProperty.slnx           Main solution (library + tests)
+ReactiveProperty-Samples.slnx   Samples solution
+```
+
+## Build, test, and run
+
+The project uses the **.NET 10 SDK** (`10.0.x`) and CI runs on **Windows**
+(the WPF/UWP projects require Windows to build the full solution).
+
+```pwsh
+# Restore, build, and test the library + tests
+dotnet restore ReactiveProperty.slnx
+dotnet build   ReactiveProperty.slnx -c Release --no-restore
+dotnet test    ReactiveProperty.slnx --no-restore --verbosity normal
+```
+
+- **Run a single test project:** `dotnet test Test/ReactiveProperty.NETStandard.Tests/ReactiveProperty.NETStandard.Tests.csproj`
+- **Samples:** open/build `ReactiveProperty-Samples.slnx`.
+- **Benchmarks:** use `Benchmark/ReactiveProperty-Benchmark.sln` (separate from the main solution).
+
+CI mirrors these commands:
+- `.github/workflows/dotnet-core-unit-testing.yml` — restore + test on every PR to `main`.
+- `.github/workflows/build-and-publish.yml` — runs on `v*` tags: bumps the version in
+  `Source/Directory.Build.props`, builds Release, tests, and pushes packages to NuGet.
+
+## Conventions you must follow
+
+### NuGet — Central Package Management
+Package versions are managed centrally (`ManagePackageVersionsCentrally=true`).
+- Add/upgrade versions **only** in `Directory.Packages.props` using `<PackageVersion Include="..." Version="..." />`.
+- In `.csproj`, reference packages **without** a version: `<PackageReference Include="..." />`.
+
+### Target frameworks (don't change casually)
+| Project | TargetFramework(s) |
+|---|---|
+| `ReactiveProperty.Core`, `ReactiveProperty.NETStandard` | `netstandard2.0;net8.0;net9.0;net472` |
+| `ReactiveProperty.Platform.Blazor` | `net8.0;net9.0;net10.0` |
+| `ReactiveProperty.Platform.WPF` | `net8.0-windows;net9.0-windows;net472` |
+| `ReactiveProperty.NETStandard.Tests` | `net9.0` |
+
+Because of `netstandard2.0`/`net472`, keep core code compatible with older frameworks
+(avoid APIs that only exist on modern .NET unless guarded).
+
+### Project settings (from `Source/Directory.Build.props`)
+- `LangVersion` is **12.0**; `Nullable` is **enable** — keep new code null-annotated.
+- Assemblies are **strong-name signed** (`key.snk`); don't break signing.
+- XML documentation is generated (`GenerateDocumentationFile=true`) — public APIs need doc comments.
+- The package **version** is `<Version>` in `Source/Directory.Build.props` (do not hand-edit for releases; the tag workflow updates it).
+
+### Code style (enforced via `.editorconfig`)
+- Indentation: **4 spaces** for `.cs`; **2 spaces** for `.csproj`/`.props`/`.targets`/XML.
+- **File-scoped namespaces** (`namespace Foo;`).
+- Prefer **`var`**; expression-bodied **properties/accessors** yes, expression-bodied **methods/constructors** no.
+- **Allman braces** (open brace on a new line); always use braces.
+- Naming: private instance fields `_camelCase`, private static fields `s_camelCase`,
+  members/types PascalCase, locals/parameters camelCase.
+- Files are **UTF-8 with BOM** and end with a final newline.
+
+## Development workflow (must follow)
+See the **`development-workflow`** skill (`.agents/skills/development-workflow/SKILL.md`) for the full policy. In short:
+- **TDD is mandatory** — drive every `Source/` change with a failing test first, then
+  Red → Green → Refactor. Not done until `dotnet test ReactiveProperty.slnx` passes.
+- **Record design/architecture decisions as ADRs** in `dev-docs/adr/` (copy `template.md`,
+  number it, add it to the index).
+- **Docs by audience** — `docs/` for users, `dev-docs/` for implementers (see below).
+
+## Testing notes
+- Framework: **MSTest** (`MSTest.TestAdapter` / `MSTest.TestFramework`).
+- Helpers: **Moq**, **Microsoft.Reactive.Testing** (`TestScheduler`), and the bundled
+  `ChainingAssertion` (`.Is(...)` fluent assertions). Blazor tests use **bunit**.
+- Add tests under the matching `Test/*` project; mirror the namespace `ReactiveProperty.Tests`.
+
+## Documentation
+- **`docs/` = user-facing**, built with **VuePress** (English + Japanese `*-ja` variants):
+  ```pwsh
+  cd docs
+  npm install
+  npm run docs:dev     # local dev server
+  npm run docs:build   # static build
+  ```
+- **`dev-docs/` = implementer/contributor-facing** (not published): architecture notes,
+  contributor workflow, and ADRs in `dev-docs/adr/`. See `dev-docs/README.md`.
+
+## Agent skills
+This repo has **two** skill locations, split by audience. Each skill is a folder containing a
+`SKILL.md` with YAML frontmatter (`name`, `description`) plus the body.
+
+- **`.agents/skills/` — for working *on* this repo (contributors).** Auto-loaded when an agent
+  works in this repository. Holds the repo's `development-workflow` skill and vendored .NET
+  build/test skills. Add a skill here only if it helps maintain ReactiveProperty itself.
+- **`skills/` — published skills for ReactiveProperty *users* (consumers).** These help agents
+  build apps that *use* ReactiveProperty (ViewModels, `ReactiveProperty`/`ReactiveCommand`,
+  validation, Rx composition). They are meant to be discovered/installed by consumers, so they
+  are **not** auto-loaded for repo work (working in this repo means building the library, not
+  consuming it). See `skills/README.md`. Use one folder per skill, e.g.
+  `skills/using-reactiveproperty/SKILL.md`.
+
+When adding a user-facing skill, put it under **`skills/`**, not `.agents/skills/`.
+
+## Quick reminders
+- Follow **TDD (Red → Green → Refactor)**; write the failing test first (see the `development-workflow` skill).
+- Record design decisions as **ADRs** in `dev-docs/adr/`.
+- Don't add package versions to `.csproj` — use `Directory.Packages.props`.
+- Keep `Source/` code compatible with `netstandard2.0` / `net472`.
+- Use `Reactive.Bindings` as the namespace for library code.
+- Run `dotnet test ReactiveProperty.slnx` (on Windows) before finishing changes.

--- a/dev-docs/README.md
+++ b/dev-docs/README.md
@@ -1,0 +1,30 @@
+# dev-docs — Implementer documentation
+
+This folder holds documentation for people working **on** ReactiveProperty
+(maintainers and contributors). It is intentionally separate from the user-facing site.
+
+| Folder | Audience | Published? |
+|--------|----------|------------|
+| [`../docs/`](../docs) | Library **users** (consumers) | Yes — built and published with VuePress |
+| `dev-docs/` (this folder) | **Implementers / contributors** | No |
+
+Put "how does a consumer use this feature?" content in `docs/`. Put "how/why is this
+implemented, and how do I contribute?" content here.
+
+## Contents
+
+- [`adr/`](./adr) — Architecture Decision Records: the log of design/architecture decisions.
+
+## Development workflow (summary)
+
+The full, authoritative policy is the `development-workflow` skill
+(`.agents/skills/development-workflow/SKILL.md`). In short:
+
+1. **TDD, always Red → Green → Refactor.** Write a failing test first, make it pass with the
+   minimum code, then refactor with tests green. A change isn't done until
+   `dotnet test ReactiveProperty.slnx` passes (on Windows).
+2. **Record design decisions as ADRs** under [`adr/`](./adr).
+3. **Docs by audience:** `docs/` for users, `dev-docs/` for implementers.
+
+See the repository [`AGENTS.md`](../AGENTS.md) for build/test commands, target frameworks,
+central package management, and code style.

--- a/dev-docs/adr/0001-adopt-tdd-adr-and-dev-docs.md
+++ b/dev-docs/adr/0001-adopt-tdd-adr-and-dev-docs.md
@@ -1,0 +1,56 @@
+# 0001. Adopt TDD, ADRs, and a dev-docs location
+
+- **Status:** Accepted
+- **Date:** 2026-06-20
+- **Deciders:** ReactiveProperty maintainers
+
+## Context
+
+ReactiveProperty is a long-lived MVVM/Rx library shipped as several NuGet packages and
+targeting a wide range of frameworks (`netstandard2.0`, `net472`, and current .NET). To keep
+quality high and the design history understandable as the project evolves, we want explicit,
+written conventions for how changes are made and how decisions are captured.
+
+Three gaps existed:
+
+1. No stated testing discipline for changes to library code.
+2. No durable record of *why* design/architecture decisions were made.
+3. Only one documentation location (`docs/`), which is the user-facing site published with
+   VuePress. There was nowhere obvious to put documentation aimed at implementers and
+   contributors, and putting it under `docs/` risks publishing internal notes.
+
+## Decision
+
+We will adopt the following development conventions, codified in the
+`development-workflow` skill (`.agents/skills/development-workflow/SKILL.md`):
+
+1. **Test-Driven Development is mandatory.** All changes to `Source/` follow a strict
+   Red → Green → Refactor cycle: write a failing test first, write the minimum production
+   code to pass, then refactor with tests green. A change is not done until
+   `dotnet test ReactiveProperty.slnx` passes.
+2. **Design decisions are recorded as ADRs** in `dev-docs/adr/`, using a lightweight
+   Nygard-style template, one file per decision, numbered sequentially.
+3. **Documentation is split by audience.** `docs/` remains user-facing (published via
+   VuePress). A new top-level **`dev-docs/`** folder holds implementer/contributor
+   documentation (including ADRs) and is not published.
+
+### Alternatives considered
+
+- **Implementer docs under `docs/` (e.g. `docs/contributing/`)** — rejected: `docs/` is the
+  VuePress build root, so internal docs could be published unintentionally and would mix
+  audiences.
+- **`eng/docs/` or `docs-dev/`** — viable, but `dev-docs/` was chosen as the clearest
+  top-level, audience-named location that is unambiguously separate from the published site.
+- **No formal decision log (rely on PR/commit history)** — rejected: decision rationale is
+  hard to find later and easily lost in noise.
+
+## Consequences
+
+- Contributors and AI agents have a single, discoverable policy (the `development-workflow`
+  skill) and a home for internal docs (`dev-docs/`).
+- Every significant future decision should add an ADR; this is light overhead per decision
+  but yields a durable, reviewable design history.
+- TDD becomes the expected default for library changes, improving regression safety across
+  the many target frameworks.
+- `dev-docs/` is excluded from the published site by virtue of living outside `docs/`; no
+  VuePress configuration change is required.

--- a/dev-docs/adr/README.md
+++ b/dev-docs/adr/README.md
@@ -1,0 +1,37 @@
+# Architecture Decision Records (ADRs)
+
+This directory records the significant design and architecture decisions for
+ReactiveProperty. Each ADR is one Markdown file describing a single decision, its context,
+and its consequences. ADRs are immutable history: once a decision changes, add a new ADR
+that supersedes the old one rather than rewriting it.
+
+We use a lightweight [Nygard-style](https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions)
+format. See [`template.md`](./template.md).
+
+## When to write an ADR
+
+Write one when you:
+
+- add or remove a public API surface, or change its semantics;
+- add a new package/project or a new external dependency;
+- change threading/scheduling, validation, or serialization behavior;
+- make a breaking change or deprecate something;
+- choose between competing implementation approaches with long-term impact.
+
+Trivial, easily reversible choices (local refactors, naming) do not need an ADR.
+
+## How to add a new ADR
+
+1. Copy [`template.md`](./template.md) to `NNNN-short-title.md`, where `NNNN` is the next
+   zero-padded number (e.g. `0002-...`).
+2. Fill in **Status**, **Context**, **Decision**, and **Consequences**.
+3. Start with `Status: Proposed`; change to `Accepted` once the decision is agreed.
+4. To reverse an earlier decision, write a new ADR and set the old one's status to
+   `Superseded by NNNN` (and the new one's `Context` should reference the old number).
+5. Add the ADR to the index below.
+
+## Index
+
+| ADR | Title | Status |
+|-----|-------|--------|
+| [0001](./0001-adopt-tdd-adr-and-dev-docs.md) | Adopt TDD, ADRs, and a dev-docs location | Accepted |

--- a/dev-docs/adr/template.md
+++ b/dev-docs/adr/template.md
@@ -1,0 +1,25 @@
+# NNNN. Short title of the decision
+
+- **Status:** Proposed <!-- Proposed | Accepted | Deprecated | Superseded by NNNN -->
+- **Date:** YYYY-MM-DD
+- **Deciders:** <!-- who made the decision -->
+
+## Context
+
+What is the problem or force driving this decision? Describe the situation, constraints,
+and any relevant background. State the facts neutrally — avoid arguing for the outcome here.
+
+## Decision
+
+The change we are making, stated clearly and in the active voice
+("We will …"). Include the chosen option.
+
+### Alternatives considered
+
+- **Option A** — brief description; why it was/wasn't chosen.
+- **Option B** — brief description; why it was/wasn't chosen.
+
+## Consequences
+
+What becomes easier or harder as a result? List the positive outcomes, the trade-offs,
+and any follow-up work or risks this decision introduces.

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,43 @@
+# skills — Agent skills for ReactiveProperty users
+
+This folder holds **published agent skills for people who *use* ReactiveProperty** in their
+own applications. They help an AI coding agent write app code with ReactiveProperty —
+ViewModels, `ReactiveProperty` / `ReactivePropertySlim`, `ReactiveCommand`,
+`ValidatableReactiveProperty`, and Rx composition — following the library's idioms.
+
+> Not to be confused with [`../.agents/skills/`](../.agents/skills), which holds skills for
+> working **on** this repository (contributors/maintainers). Skills here are for **consumers**
+> of the library and are intentionally **not** auto-loaded when working in this repo.
+
+## How consumers use these
+
+Copy (or install) a skill folder into the agent's skills location for their own project —
+for example the project-level `.agents/skills/` of the consuming repository, or a personal
+skills directory. Each skill is self-contained.
+
+## Layout
+
+One folder per skill, each with a `SKILL.md`:
+
+```
+skills/
+  using-reactiveproperty/
+    SKILL.md            # name + description frontmatter, then the guidance body
+    references/         # optional supporting docs the skill links to
+```
+
+## Authoring a skill
+
+`SKILL.md` starts with YAML frontmatter, then Markdown guidance:
+
+```markdown
+---
+name: using-reactiveproperty
+description: <when an agent should use this skill — be specific; this is what triggers it>
+---
+# Using ReactiveProperty
+...guidance, patterns, and examples...
+```
+
+Keep the content focused on **consuming** the library (app/ViewModel code), not on building
+ReactiveProperty itself. For repo-internal conventions, see [`../AGENTS.md`](../AGENTS.md).


### PR DESCRIPTION
## Why

The repo had no single place describing how to build, test, and contribute, nor an agreed development workflow or a home for design decisions. This adds that guidance so both humans and AI coding agents can work consistently.

## What's included

- **`AGENTS.md`** — repo guide grounded in the actual config: project overview, build/test commands (`dotnet restore/build/test ReactiveProperty.slnx`, .NET 10 SDK, Windows required for WPF/UWP), Central Package Management rule, per-project target frameworks, `Reactive.Bindings` root namespace, signing, versioning, and `.editorconfig` code style.
- **`development-workflow` skill** (`.agents/skills/development-workflow/SKILL.md`) — the team policy: mandatory TDD (Red -> Green -> Refactor), recording design decisions as ADRs, and the documentation split by audience.
- **`dev-docs/`** — a new top-level home for implementer/contributor documentation, intentionally separate from the published VuePress `docs/` site (so internal notes are not published). Includes an ADR index, a Nygard-style template, and `0001-adopt-tdd-adr-and-dev-docs.md` recording these decisions.
- **`skills/`** — a home for published, user-facing ReactiveProperty consumer skills, with a README explaining how it differs from `.agents/skills/`.

## Notes for reviewers

- Two skill locations by design: `.agents/skills/` is for working *on* the library (auto-loaded for repo work); `skills/` is for people *using* ReactiveProperty in their apps (distributed to consumers, not auto-loaded here). This split is documented in `AGENTS.md`.
- Documentation only. No source, build, or test changes, so nothing to run.
- Placement of `dev-docs/` and `skills/` was chosen with the maintainer; both sit outside `docs/` so VuePress does not publish them and no VuePress config change is needed.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>