### PR TITLE
Fix value-type Remove reporting and harden property selector parsing in R3 bridge

### DIFF
--- a/Source/ReactiveProperty.R3/Extensions/INotifyCollectionChangedExtensions.cs
+++ b/Source/ReactiveProperty.R3/Extensions/INotifyCollectionChangedExtensions.cs
@@ -324,20 +324,105 @@ public static class INotifyCollectionChangedExtensions
         typeof(TElement).GetProperty(propertyName)
         ?? throw new ArgumentException($"'{propertyName}' is not a property of '{typeof(TElement).FullName}'.", nameof(propertyName));
 
-    private static string ResolvePropertyName(string? propertyName)
+    private static string ResolvePropertyName(string? propertyExpression)
     {
-        if (string.IsNullOrWhiteSpace(propertyName))
+        if (string.IsNullOrWhiteSpace(propertyExpression))
         {
-            throw new ArgumentException("Property name is required.", nameof(propertyName));
+            throw new ArgumentException("Property selector is required.", "propertyName");
         }
 
-        var name = propertyName!.Trim();
-        var lastDotIndex = name.LastIndexOf('.');
-        if (lastDotIndex >= 0)
+        var expression = propertyExpression!.Trim();
+
+        // Strip an optional lambda prefix ("x =>", "(x) =>", "static x =>") so only the body remains.
+        var arrowIndex = expression.IndexOf("=>", StringComparison.Ordinal);
+        if (arrowIndex < 0)
         {
-            name = name.Substring(lastDotIndex + 1);
+            // An explicit, already-resolved property name (e.g. propertyName: nameof(Item.Name)).
+            var bare = StripVerbatimPrefix(expression);
+            if (IsValidIdentifier(bare))
+            {
+                return bare;
+            }
+
+            throw NotSingleLevelSelector(propertyExpression);
         }
 
-        return name.Trim();
+        var body = expression.Substring(arrowIndex + 2).Trim();
+
+        // A single-level selector body is "<receiver>.<Property>" with exactly one top-level member
+        // access. Dots inside parentheses/brackets (e.g. a cast such as "((My.Ns.Base)x).Name") do not
+        // count, so casts are accepted while nested paths ("x.Child.Name") are rejected.
+        if (!TryGetSingleLevelProperty(body, out var name))
+        {
+            throw NotSingleLevelSelector(propertyExpression);
+        }
+
+        return name;
+    }
+
+    private static bool TryGetSingleLevelProperty(string body, out string name)
+    {
+        name = string.Empty;
+        var depth = 0;
+        var topLevelDotCount = 0;
+        var lastTopLevelDot = -1;
+        for (var i = 0; i < body.Length; i++)
+        {
+            switch (body[i])
+            {
+                case '(':
+                case '[':
+                    depth++;
+                    break;
+                case ')':
+                case ']':
+                    depth--;
+                    break;
+                case '.' when depth == 0:
+                    topLevelDotCount++;
+                    lastTopLevelDot = i;
+                    break;
+            }
+        }
+
+        if (topLevelDotCount != 1)
+        {
+            return false;
+        }
+
+        var candidate = StripVerbatimPrefix(body.Substring(lastTopLevelDot + 1).Trim());
+        if (!IsValidIdentifier(candidate))
+        {
+            return false;
+        }
+
+        name = candidate;
+        return true;
+    }
+
+    private static string StripVerbatimPrefix(string value) =>
+        value.StartsWith("@", StringComparison.Ordinal) ? value.Substring(1) : value;
+
+    private static ArgumentException NotSingleLevelSelector(string propertyExpression) =>
+        new(
+            $"Only a single-level property selector such as 'x => x.PropertyName' is supported, but '{propertyExpression}' was provided. Nested property paths are not supported.",
+            "propertyName");
+
+    private static bool IsValidIdentifier(string value)
+    {
+        if (value.Length == 0 || !(char.IsLetter(value[0]) || value[0] == '_'))
+        {
+            return false;
+        }
+
+        for (var i = 1; i < value.Length; i++)
+        {
+            if (!(char.IsLetterOrDigit(value[i]) || value[i] == '_'))
+            {
+                return false;
+            }
+        }
+
+        return true;
     }
 }

--- a/Source/ReactiveProperty.R3/ReadOnlyReactiveCollection.cs
+++ b/Source/ReactiveProperty.R3/ReadOnlyReactiveCollection.cs
@@ -267,6 +267,14 @@ public readonly struct CollectionChanged<T>
         new(NotifyCollectionChangedAction.Add, index, values.ToArray(), -1, null);
 
     /// <summary>
+    /// Creates a remove change that carries only the index. The removed value is
+    /// resolved from the backing collection when the change is applied, so this is
+    /// safe for value-type elements (where <c>default</c> is not <see langword="null"/>).
+    /// </summary>
+    public static CollectionChanged<T> Remove(int index) =>
+        new(NotifyCollectionChangedAction.Remove, index, null, -1, null);
+
+    /// <summary>
     /// Creates a remove change.
     /// </summary>
     public static CollectionChanged<T> Remove(int index, T? value) =>
@@ -437,7 +445,7 @@ public static class ReadOnlyReactiveCollectionExtensions
         var convertedChanges = collectionChanged.Select(x => x.Action switch
         {
             NotifyCollectionChangedAction.Add => CollectionChanged<TResult>.Add(x.Index, x.Values!.Select(converter)),
-            NotifyCollectionChangedAction.Remove => CollectionChanged<TResult>.Remove(x.Index, default(TResult)),
+            NotifyCollectionChangedAction.Remove => CollectionChanged<TResult>.Remove(x.Index),
             NotifyCollectionChangedAction.Replace => CollectionChanged<TResult>.Replace(x.Index, converter(x.Value!)),
             NotifyCollectionChangedAction.Move => CollectionChanged<TResult>.Move(x.OldIndex, x.Index, default),
             NotifyCollectionChangedAction.Reset => CollectionChanged<TResult>.ResetWithSource(x.Source?.Select(converter)),

--- a/Test/ReactiveProperty.R3.Tests/CollectionObservationTest.cs
+++ b/Test/ReactiveProperty.R3.Tests/CollectionObservationTest.cs
@@ -1,5 +1,6 @@
 ﻿#nullable enable
 
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
@@ -90,6 +91,32 @@ public sealed class CollectionObservationTest
         changedNames.Is(nameof(Item.Name));
     }
 
+    [TestMethod]
+    public void ObserveElementPropertyAcceptsExplicitBarePropertyName()
+    {
+        var item = new Item { Name = "first" };
+        var source = new ObservableCollection<Item> { item };
+        var values = new List<string>();
+        Func<Item, string> selector = x => x.Name;
+
+        using var subscription = source
+            .ObserveElementProperty(selector, propertyName: nameof(Item.Name))
+            .Subscribe(x => values.Add($"{x.Property.Name}:{x.Value}"));
+
+        item.Name = "changed";
+
+        values.Is("Name:first", "Name:changed");
+    }
+
+    [TestMethod]
+    public void ObserveElementPropertyRejectsNestedPropertySelector()
+    {
+        var source = new ObservableCollection<Outer> { new() };
+
+        Assert.ThrowsExactly<ArgumentException>(() =>
+            source.ObserveElementProperty(x => x.Inner.Name));
+    }
+
     private sealed class Item : INotifyPropertyChanged
     {
         private string _name = "";
@@ -107,6 +134,42 @@ public sealed class CollectionObservationTest
         }
 
         public Subject<string> NameChanged { get; } = new();
+
+        public event PropertyChangedEventHandler? PropertyChanged;
+    }
+
+    private sealed class Outer : INotifyPropertyChanged
+    {
+        private string _name = "outer";
+
+        public Inner Inner { get; } = new();
+
+        public string Name
+        {
+            get => _name;
+            set
+            {
+                _name = value;
+                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Name)));
+            }
+        }
+
+        public event PropertyChangedEventHandler? PropertyChanged;
+    }
+
+    private sealed class Inner : INotifyPropertyChanged
+    {
+        private string _name = "";
+
+        public string Name
+        {
+            get => _name;
+            set
+            {
+                _name = value;
+                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Name)));
+            }
+        }
 
         public event PropertyChangedEventHandler? PropertyChanged;
     }

--- a/Test/ReactiveProperty.R3.Tests/ReadOnlyReactiveCollectionTest.cs
+++ b/Test/ReactiveProperty.R3.Tests/ReadOnlyReactiveCollectionTest.cs
@@ -43,6 +43,28 @@ public sealed class ReadOnlyReactiveCollectionTest
     }
 
     [TestMethod]
+    public void RemoveReportsActualValueForValueTypeElements()
+    {
+        var source = new ObservableCollection<int> { 10, 20, 30 };
+        var collection = source.ToReadOnlyReactiveCollection();
+        var removed = new List<int?>();
+
+        ((INotifyCollectionChanged)collection).CollectionChanged += (_, e) =>
+        {
+            if (e.Action == NotifyCollectionChangedAction.Remove)
+            {
+                removed.Add((int?)e.OldItems?[0]);
+            }
+        };
+
+        source.RemoveAt(0);
+
+        collection.Is(20, 30);
+        removed.Count.Is(1);
+        removed[0].Is(10);
+    }
+
+    [TestMethod]
     public void AppliesObservableChangeStreamAndResetStream()
     {
         var add = new Subject<string>();


### PR DESCRIPTION
## Why

A review of the new `ReactiveProperty.R3` collection bridge surfaced two correctness issues that would silently give consumers wrong data. This PR fixes both and adds regression tests.

## What changed

**1. Value-type `Remove` reported `default(T)` instead of the actual element**

The converter projection path passed `default(TResult)` into `CollectionChanged<T>.Remove`. For value types `default` is non-null, so it was surfaced as `OldItems` and callers observing a removed `int`/`struct` element saw `0`/`default` rather than the real value. Added a `Remove(int index)` factory (`Values = null`) so `ApplyRemove` falls back to the real `_source[index]` value. The reference-type and non-converter paths are unchanged.

**2. `ResolvePropertyName` accepted nested selectors and was fragile around casts/explicit names**

Rewrote the parser so it:
- accepts an explicit bare property name when no lambda arrow is present (e.g. `propertyName: nameof(Item.Name)`), and
- for lambda bodies, requires exactly one top-level member access by counting dots at parenthesis/bracket depth 0. This accepts cast receivers like `((Base)x).Name` while rejecting nested paths like `x => x.Child.Name`, which the bridge does not support.

This second change also reverses a public API regression caught during review, where an earlier hardening attempt wrongly rejected explicit bare property names.

## Notes for reviewers

- Single-level-only property selectors are intentional per the design doc (section 4.1.1); this PR enforces that boundary rather than changing it.
- Known, intentionally-unfixed limitations (out of scope, no regression): the converter emits single-item `Remove` (fine for standard `ObservableCollection<T>`), and the selector check is still a lightweight heuristic, so a receiver-substituting body like `x => other.Name` is accepted when `TElement` also has a `Name` property. True validation would require expression-tree parsing.

## Testing

Added tests for value-type `Remove`, explicit bare property names, and nested-selector rejection. All 11 R3 tests pass; the R3 package builds clean (0 warnings) across netstandard2.0, net8.0, net9.0, net10.0, and net472.