### PR TITLE
Add tests + evaluation notes for the R3 migration sample

### DIFF
--- a/.github/workflows/samples-r3-tests.yml
+++ b/.github/workflows/samples-r3-tests.yml
@@ -1,0 +1,27 @@
+name: Samples R3 migration tests
+
+# Gating safety net for the R3 migration sample. Scoped to the single
+# ReactivePropertySamples.R3.Tests project so it builds/restores only the R3 bridge
+# and the migrated sample ViewModels - it does NOT pull in the WPF/Blazor/Prism/MahApps
+# samples, keeping the check fast enough to run on every PR.
+
+on:
+  pull_request:
+    branches: [ main, feature/r3-migration-support ]
+
+env:
+  DOTNET_VERSION: 10.0.x
+
+jobs:
+  test:
+
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: ${{ env.DOTNET_VERSION }}
+    - name: Test R3 migration sample
+      run: dotnet test Samples/ReactivePropertySamples.R3.Tests/ReactivePropertySamples.R3.Tests.csproj --verbosity normal

--- a/ReactiveProperty-Samples.slnx
+++ b/ReactiveProperty-Samples.slnx
@@ -22,6 +22,7 @@
   </Folder>
   <Folder Name="/R3Migration/">
     <Project Path="Samples/ReactivePropertySamples.R3.Shared/ReactivePropertySamples.R3.Shared.csproj" />
+    <Project Path="Samples/ReactivePropertySamples.R3.Tests/ReactivePropertySamples.R3.Tests.csproj" />
     <Project Path="Samples/ReactivePropertySamples.R3.WPF/ReactivePropertySamples.R3.WPF.csproj" />
   </Folder>
   <Folder Name="/WithPrism/">

--- a/Samples/ReactivePropertySamples.R3.Tests/CollectionsViewModelTests.cs
+++ b/Samples/ReactivePropertySamples.R3.Tests/CollectionsViewModelTests.cs
@@ -1,0 +1,38 @@
+﻿using System.Windows.Input;
+using ReactivePropertySamples.Migrated.ViewModels;
+
+namespace ReactivePropertySamples.R3.Tests;
+
+// CollectionsViewModel also exposes GuidViewModels (updated via ObserveOnThreadPool + a captured
+// SynchronizationContext) and FilteredItems (driven by a per-item ReactiveTimer with random values).
+// Those paths are time- and thread-dependent and cannot be asserted deterministically in a headless
+// unit test without a SynchronizationContext pump / TimeProvider seam the sample does not expose, so
+// they are intentionally not covered here. The synchronous ReactiveCommand + ObservableCollection
+// path is the deterministic surface and is covered below.
+[TestClass]
+public class CollectionsViewModelTests
+{
+    [TestMethod]
+    public void AddToReactiveCollectionCommand_AddsItem()
+    {
+        using var vm = new CollectionsViewModel();
+        Assert.AreEqual(0, vm.ReactiveCollection.Count);
+
+        ((ICommand)vm.AddToReactiveCollectionCommand).Execute(null);
+
+        Assert.AreEqual(1, vm.ReactiveCollection.Count);
+    }
+
+    [TestMethod]
+    public void ClearReactiveCollectionCommand_EmptiesCollection()
+    {
+        using var vm = new CollectionsViewModel();
+        ((ICommand)vm.AddToReactiveCollectionCommand).Execute(null);
+        ((ICommand)vm.AddToReactiveCollectionCommand).Execute(null);
+        Assert.AreEqual(2, vm.ReactiveCollection.Count);
+
+        ((ICommand)vm.ClearReactiveCollectionCommand).Execute(null);
+
+        Assert.AreEqual(0, vm.ReactiveCollection.Count);
+    }
+}

--- a/Samples/ReactivePropertySamples.R3.Tests/CreateFromPocoViewModelTests.cs
+++ b/Samples/ReactivePropertySamples.R3.Tests/CreateFromPocoViewModelTests.cs
@@ -1,0 +1,39 @@
+﻿using ReactivePropertySamples.Migrated.ViewModels;
+
+namespace ReactivePropertySamples.R3.Tests;
+
+[TestClass]
+public class CreateFromPocoViewModelTests
+{
+    [TestMethod]
+    public void TwoWay_PropertyAndPocoStayInSync()
+    {
+        using var vm = new CreateFromPocoViewModel();
+
+        Assert.AreEqual("Kazuki", vm.FirstNameTwoWay.Value);
+
+        vm.FirstNameTwoWay.Value = "Taro";
+        Assert.AreEqual("Taro", vm.Poco.FirstName);
+
+        vm.Poco.FirstName = "Jiro";
+        Assert.AreEqual("Jiro", vm.FirstNameTwoWay.Value);
+    }
+
+    [TestMethod]
+    public void OneWay_PocoChangePropagatesToProperty()
+    {
+        using var vm = new CreateFromPocoViewModel();
+
+        vm.Poco.LastName = "Yamada";
+        Assert.AreEqual("Yamada", vm.LastNameOneWay.Value);
+    }
+
+    [TestMethod]
+    public void OneWayToSource_PropertyChangeWritesBackToPoco()
+    {
+        using var vm = new CreateFromPocoViewModel();
+
+        vm.FirstNameOneWayToSource.Value = "Hanako";
+        Assert.AreEqual("Hanako", vm.Poco.FirstName);
+    }
+}

--- a/Samples/ReactivePropertySamples.R3.Tests/EventToReactiveViewModelTests.cs
+++ b/Samples/ReactivePropertySamples.R3.Tests/EventToReactiveViewModelTests.cs
@@ -1,0 +1,30 @@
+﻿using System.Windows.Input;
+using ReactivePropertySamples.Migrated.ViewModels;
+
+namespace ReactivePropertySamples.R3.Tests;
+
+[TestClass]
+public class EventToReactiveViewModelTests
+{
+    [TestMethod]
+    public void OpenFileCommand_Execute_SetsOpenedFile()
+    {
+        using var vm = new EventToReactiveViewModel();
+
+        ((ICommand)vm.OpenFileCommand).Execute("C:\\sample.txt");
+
+        Assert.AreEqual("You selected C:\\sample.txt", vm.OpenedFile.Value);
+    }
+
+    [TestMethod]
+    public void OpenFileCommand_CanExecuteFollowsCanExecuteProperty()
+    {
+        using var vm = new EventToReactiveViewModel();
+        var command = (ICommand)vm.OpenFileCommand;
+
+        Assert.IsTrue(command.CanExecute(null), "CanExecute starts true.");
+
+        vm.CanExecute.Value = false;
+        Assert.IsFalse(command.CanExecute(null), "CanExecute false -> command cannot execute.");
+    }
+}

--- a/Samples/ReactivePropertySamples.R3.Tests/ReactiveCommandViewModelTests.cs
+++ b/Samples/ReactivePropertySamples.R3.Tests/ReactiveCommandViewModelTests.cs
@@ -1,0 +1,42 @@
+﻿using System.Windows.Input;
+using ReactivePropertySamples.Migrated.ViewModels;
+
+namespace ReactivePropertySamples.R3.Tests;
+
+[TestClass]
+public class ReactiveCommandViewModelTests
+{
+    [TestMethod]
+    public void CreateAndSubscribeCommand_Execute_SetsInvokedOutputs()
+    {
+        using var vm = new ReactiveCommandViewModel();
+        Assert.AreEqual("", vm.InvokedDateTime.Value);
+
+        ((ICommand)vm.CreateAndSubscribeCommand).Execute(null);
+
+        StringAssert.Contains(vm.InvokedDateTime.Value, "command was invoked");
+        StringAssert.Contains(vm.InvokedDateTimeFromCommand.Value, "command was invoked");
+    }
+
+    [TestMethod]
+    public void CreateFromIObservableBoolCommand_CanExecuteFollowsIsChecked()
+    {
+        using var vm = new ReactiveCommandViewModel();
+        var command = (ICommand)vm.CreateFromIObservableBoolCommand;
+
+        Assert.IsFalse(command.CanExecute(null), "IsChecked starts false.");
+
+        vm.IsChecked.Value = true;
+        Assert.IsTrue(command.CanExecute(null), "IsChecked true -> command can execute.");
+    }
+
+    [TestMethod]
+    public void ReactiveCommandWithParameter_Execute_PassesParameter()
+    {
+        using var vm = new ReactiveCommandViewModel();
+
+        ((ICommand)vm.ReactiveCommandWithParameter).Execute("abc");
+
+        Assert.AreEqual("The command was invoked with abc.", vm.ReactiveCommandWithParameterOutput.Value);
+    }
+}

--- a/Samples/ReactivePropertySamples.R3.Tests/ReactivePropertySamples.R3.Tests.csproj
+++ b/Samples/ReactivePropertySamples.R3.Tests/ReactivePropertySamples.R3.Tests.csproj
@@ -1,0 +1,29 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <RootNamespace>ReactivePropertySamples.R3.Tests</RootNamespace>
+    <LangVersion>latest</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="MSTest.TestAdapter" />
+    <PackageReference Include="MSTest.TestFramework" />
+    <PackageReference Include="R3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\ReactivePropertySamples.R3.Shared\ReactivePropertySamples.R3.Shared.csproj" />
+    <ProjectReference Include="..\..\Source\ReactiveProperty.R3\ReactiveProperty.R3.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Microsoft.VisualStudio.TestTools.UnitTesting" />
+  </ItemGroup>
+
+</Project>

--- a/Samples/ReactivePropertySamples.R3.Tests/ValidationViewModelTests.cs
+++ b/Samples/ReactivePropertySamples.R3.Tests/ValidationViewModelTests.cs
@@ -1,0 +1,73 @@
+﻿using System.ComponentModel;
+using System.Windows.Input;
+using ReactivePropertySamples.Migrated.ViewModels;
+
+namespace ReactivePropertySamples.R3.Tests;
+
+[TestClass]
+public class ValidationViewModelTests
+{
+    [TestMethod]
+    public void WithDataAnnotations_EmptyIsInvalid_NonEmptyClearsError()
+    {
+        using var vm = new ValidationViewModel();
+
+        vm.WithDataAnnotations.Value = "valid";
+        Assert.AreEqual("", vm.WithDataAnnotationsErrorMessage.Value);
+
+        vm.WithDataAnnotations.Value = "";
+        Assert.AreEqual("Required property", vm.WithDataAnnotationsErrorMessage.Value);
+    }
+
+    [TestMethod]
+    public void WithCustomValidationLogic_RequiresHyphen()
+    {
+        using var vm = new ValidationViewModel();
+
+        // The bridge ValidatableReactiveProperty validates eagerly, so the initial empty value fails.
+        Assert.AreEqual("Require '-'", vm.WithCustomValidationLogicErrorMessage.Value);
+
+        vm.WithCustomValidationLogic.Value = "a-b";
+        Assert.AreEqual("", vm.WithCustomValidationLogicErrorMessage.Value);
+    }
+
+    [TestMethod]
+    public void IgnoreInitialValidationError_StartsValid_ThenFlagsAfterEdit()
+    {
+        using var vm = new ValidationViewModel();
+
+        var errorInfo = (INotifyDataErrorInfo)vm.IgnoreInitialValidationError;
+        Assert.IsFalse(errorInfo.HasErrors, "Initial validation error should be suppressed.");
+
+        vm.IgnoreInitialValidationError.Value = "x";
+        vm.IgnoreInitialValidationError.Value = "";
+        Assert.IsTrue(errorInfo.HasErrors, "Validation should flag the empty value after an edit.");
+    }
+
+    [TestMethod]
+    public void FirstName_TwoWaySyncsWithPoco()
+    {
+        using var vm = new ValidationViewModel();
+
+        Assert.AreEqual("Kazuki", vm.FirstName.Value);
+
+        vm.FirstName.Value = "Taro";
+        Assert.AreEqual("Taro", vm.Poco.FirstName);
+
+        vm.Poco.FirstName = "Jiro";
+        Assert.AreEqual("Jiro", vm.FirstName.Value);
+    }
+
+    [TestMethod]
+    public void SubmitCommand_CanExecuteReflectsValidity()
+    {
+        using var vm = new ValidationViewModel();
+        var command = (ICommand)vm.SubmitCommand;
+
+        Assert.IsFalse(command.CanExecute(null), "Both fields start invalid.");
+
+        vm.WithDataAnnotations.Value = "ok";
+        vm.WithCustomValidationLogic.Value = "a-b";
+        Assert.IsTrue(command.CanExecute(null), "Both fields valid -> command can execute.");
+    }
+}

--- a/dev-docs/adr/0003-reactiveproperty-r3-migration-bridge.md
+++ b/dev-docs/adr/0003-reactiveproperty-r3-migration-bridge.md
@@ -86,3 +86,8 @@ Three sub-decisions are confirmed here (see `design.md` §9):
 - A few constructs cannot be rewritten mechanically (custom `IScheduler`, `ReactivePropertyMode`,
   `System.IObservable<T>` interop boundaries, and platform helpers such as
   `EventToReactiveCommand`); these are surfaced as manual-review items rather than guessed.
+
+## See also
+
+- [Skill evaluation](../r3-migration/skill-evaluation.md) — end-to-end validation of the
+  migration skill (3 findings incl. the fixed YAML frontmatter bug, plus 51-rule conformance).

--- a/dev-docs/r3-migration/design.md
+++ b/dev-docs/r3-migration/design.md
@@ -575,6 +575,10 @@ public static class INotifyPropertyChangedExtensions
 The skill is **execution-centric**: it drives code rewrites from a mapping table, then surfaces only
 the spots that need manual review.
 
+> **See also:** [`skill-evaluation.md`](skill-evaluation.md) records the end-to-end validation of
+> this skill (3 findings, incl. the fixed YAML frontmatter bug and the `rules.json` install-path
+> friction, plus the 51-rule conformance check).
+
 ### 5.1 `SKILL.md` flow
 
 1. Ensure the project references `R3` and `ReactiveProperty.R3`, and drops `ReactiveProperty` /

--- a/dev-docs/r3-migration/skill-evaluation.md
+++ b/dev-docs/r3-migration/skill-evaluation.md
@@ -1,0 +1,134 @@
+# Skill evaluation — `migrating-reactiveproperty-to-r3`
+
+Maintainer-facing record of how the `migrating-reactiveproperty-to-r3` skill was validated
+end-to-end, what it got right, and the three issues the evaluation surfaced. This distills a
+longer evaluation run; the full CLI transcripts are **not** committed (they live outside the
+repo as evaluation evidence) — one trimmed excerpt is embedded below.
+
+## Method
+
+A real GitHub Copilot CLI (`copilot` v1.0.64) migration of a purpose-built `net10.0-windows`
+WPF lab app was driven the way an end user would: scoped, incremental, realistic prompts, no
+blanket delegation. The lab kept three snapshots (`01-before`, `02-in-progress`,
+`03-completed`) to prove the before / partway / after states, and the migrated output was
+checked rule-by-rule against `skills/migrating-reactiveproperty-to-r3/references/rules.json`.
+
+The committed sample under `Samples/ReactivePropertySamples.R3.*` is the shipped equivalent of
+the lab's `03-completed`, and `Samples/ReactivePropertySamples.R3.Tests` is the regression net
+that locks in the behaviors this evaluation verified by hand.
+
+## Bottom line
+
+A regular user **can** complete the migration with this skill and the output is correct: the
+`03-completed` snapshot built clean (0 warnings, 0 errors, including the WPF/XAML app) and all
+existing tests passed. In a no-special-flags plan run the agent produced a correct rule-by-rule
+plan citing **17 distinct ruleIds** (`RP-PROP-SLIM`, `RP-PROP-BINDING`,
+`RP-TO-PROP-AS-SYNCHRONIZED`, `RP-VALIDATABLE-PROP`, `RP-ASYNC-COMMAND`, `RP-NOTIFY-BUSY`,
+`RP-MANUAL-MODE`, `RP-MANUAL-SCHEDULER`, `RP-EVENT-TO-COMMAND`, …). Those ruleIds exist **only**
+in `references/rules.json` — `SKILL.md` contains none — which is hard proof the rules table, not
+just the prose, drove the result. Both genuine manual-review cases were flagged (not guessed).
+
+## Findings
+
+### Finding 1 (shipped bug — FIXED) — invalid YAML frontmatter silently dropped the skill
+
+`SKILL.md` had an **unquoted** YAML `description:` plain scalar whose text contained `: `
+(colon-space) in `...(references/rules.json): everything R3 already provides...`. A YAML plain
+scalar cannot contain `": "`, so the frontmatter failed to parse and the CLI **silently dropped
+the skill** from `<available_skills>` — nothing logged, the skill simply never appeared. Impact:
+every consumer of the published skill. The `winui` skill is immune only because it wraps its
+whole description in double quotes.
+
+**Fix applied:** single-quote the description (the text has no apostrophes, so the embedded
+`"..."` examples are preserved verbatim; only the quoting changed). Verified via the request
+payload log (`~/.copilot/logs/process-*.log`): occurrences of `migrating-reactiveproperty` went
+**0 → present** after the fix.
+
+**Follow-up worth doing:** lint skill frontmatter with a real YAML parser at publish time, or
+document "always quote `description`."
+
+### Finding 2 (mostly install-guidance) — an out-of-tree install makes `view` of `rules.json` fail and get mislabeled
+
+The skill's whole design is "drive the rewrite from `references/rules.json`," so the agent must
+be able to read that file. The structured `view`/read tool is scoped to the working tree (plus
+any `--add-dir` paths). When the skill is installed in the **personal** `~/.copilot/skills/`, it
+lives **outside** the project, so a naïve `view` of its `references/rules.json` is denied — and
+the agent narrated that denial as an org "content-exclusion policy," which is simply wrong and
+nearly derailed the evaluation.
+
+Controlled probes pinned the cause to install location, not content policy. The decisive one
+(Probe E): install the **same** skill in-tree under the project's `.agents/skills/<name>/` —
+exactly what `skills/README.md` recommends first — and the `view` returns `VIEW=ok` with **zero
+friction**, no shell fallback, no false "content-exclusion." So this is **first** a
+documentation/install-guidance issue and only secondarily a skill-robustness gap.
+
+Remediation, in recommended order:
+
+1. **(Primary) Install in-tree under `.agents/skills/<name>/`.** `rules.json` is then inside the
+   working tree and `view` reads it directly. Matches `skills/README.md`. *Downside:* per-project
+   copy.
+2. **(If a personal/global install is preferred) Harden `SKILL.md`.** Tell the agent that
+   `references/rules.json` is part of the installed skill and, if a structured `view` is denied
+   because the skill is out-of-tree, to read it via a shell/Node/Python read (or request
+   `--add-dir`) and **never** report it as "content-exclusion." *Downside:* relies on the agent
+   honoring the instruction; still a shell workaround.
+3. **(Last resort) Inline the mapping into `SKILL.md`.** Always in context, never file-scoped, but
+   the full table is ≈30 KB / 51 rules and bloats every activation. Inline only a compact subset,
+   consciously.
+
+Trimmed transcript excerpt (personal `~/.copilot/skills/` install; the friction this is about):
+
+```text
+I'll read the rules file first, then inventory the ViewModels project.
+The rules.json read was denied. Let me retry it ...
+The skills path is blocked for my direct tools in non-interactive mode.
+Now trying PowerShell: ... Now trying Node.js:
+Great! The file was successfully read via Node.js.
+The agent copied rules.json to an accessible location ... place it inside my working directory
+```
+
+### Finding 3 (skill-accuracy nuance) — `RP-VALIDATE-ATTRIBUTE` → `EnableValidation` changes validation timing
+
+`RP-VALIDATE-ATTRIBUTE` maps single-property DataAnnotations
+(`prop.SetValidateAttribute(() => x.Name)`) to the `r3-direct`
+`BindableReactiveProperty<T>.EnableValidation(() => x.Name)`. Functionally reasonable, but R3's
+`EnableValidation` **defers validation until a subscriber / WPF binding attaches**, whereas
+ReactiveProperty's `SetValidateAttribute` validates eagerly. A headless test that asserts an
+empty value is invalid *immediately* therefore fails after the mechanical rewrite. The agent
+detected this with a runtime probe and deviated to the eager-validating
+`ValidatableReactiveProperty<T>` (a `reactiveproperty-r3` type), flagging the deviation for human
+confirmation.
+
+This is also why `ReactivePropertySamples.R3.Tests/ValidationViewModelTests` asserts validation
+on **transitions** (valid → cleared, empty → "Required property") rather than at construction.
+
+**Recommendation:** add a note to `RP-VALIDATE-ATTRIBUTE` (and/or `SKILL.md`) that
+`EnableValidation` is lazy, so code/tests relying on eager validation should trigger validation
+explicitly or use `ValidatableReactiveProperty<T>`.
+
+## Rule conformance (51 rules)
+
+All 51 rules in `references/rules.json` were read and every migrated symbol in the completed
+sample was compared against them. Every symbol is rules-conformant; the only deviation is the
+justified `RP-VALIDATE-ATTRIBUTE` → `ValidatableReactiveProperty<T>` swap above. Representative
+rows:
+
+| Symbol (before) | Rule | Target | Migrated to |
+|---|---|---|---|
+| `ReactivePropertySlim<T>` | RP-PROP-SLIM | r3-direct | `R3.ReactiveProperty<T>` |
+| `ReactiveProperty<T>` (bound) | RP-PROP-BINDING | r3-direct | `R3.BindableReactiveProperty<T>` |
+| `ReactiveCommand` / `<T>` | RP-COMMAND | r3-direct | `R3.ReactiveCommand` / `<T>` |
+| `ObserveProperty` | RP-OBSERVE-PROPERTY | r3-direct | `ObservePropertyChanged` |
+| `ValidatableReactiveProperty<T>` | RP-VALIDATABLE-PROP | reactiveproperty-r3 | `Reactive.Bindings.R3.ValidatableReactiveProperty<T>` |
+| `AsyncReactiveCommand` | RP-ASYNC-COMMAND | reactiveproperty-r3 | `Reactive.Bindings.R3.AsyncReactiveCommand` |
+| `ToReactivePropertyAsSynchronized` | RP-TO-PROP-AS-SYNCHRONIZED | reactiveproperty-r3 | bridge `ToReactivePropertyAsSynchronized` |
+| `EventToReactiveCommand` (XAML) | RP-EVENT-TO-COMMAND | reactiveproperty-r3 | `Reactive.Bindings.R3.Interactivity` (ReactiveProperty.R3.WPF) |
+| `ReactivePropertyMode` arg | RP-MANUAL-MODE | manualReview | dropped + documented (flagged) |
+| custom `IScheduler` arg | RP-MANUAL-SCHEDULER | manualReview | dropped + documented (flagged) |
+| `SetValidateAttribute` | RP-VALIDATE-ATTRIBUTE | r3-direct | `ValidatableReactiveProperty<T>` (Finding 3) |
+
+## See also
+
+- [ADR-0003 — ReactiveProperty.R3 migration bridge + skill](../adr/0003-reactiveproperty-r3-migration-bridge.md)
+- [Detailed design](design.md) — §5 covers the skill and `rules.json` schema.
+- User-facing guide: `docs/docs/advanced/r3-migration.md`.

--- a/docs/docs/advanced/r3-migration.md
+++ b/docs/docs/advanced/r3-migration.md
@@ -81,6 +81,20 @@ public sealed class ViewModel
 }
 ```
 
+## Runnable sample
+
+This repository ships a **before/after pair** of WPF apps you can open side by side to see a full
+migration in context:
+
+- **Before** — `Samples/ReactivePropertySamples.WPF` (with `Samples/ReactivePropertySamples.Shared`):
+  the original app built on `Reactive.Bindings` (ReactiveProperty).
+- **After** — `Samples/ReactivePropertySamples.R3.WPF` (with
+  `Samples/ReactivePropertySamples.R3.Shared`): the same app migrated to R3 + `ReactiveProperty.R3`.
+
+The ViewModels live in the `.Shared` projects, so diffing the two `.Shared` folders shows exactly
+which symbols changed and how. The migrated ViewModels are additionally covered by
+`Samples/ReactivePropertySamples.R3.Tests`, which locks in the behaviors described below.
+
 ## Migrate with the GitHub Copilot CLI
 
 The repository ships a migration **skill** at `skills/migrating-reactiveproperty-to-r3/`. It turns
@@ -198,6 +212,10 @@ file, line, and a note. Expect a small list, typically:
 - **`System.IObservable<T>` boundaries** that must stay on `System.Reactive` (public APIs,
   third-party Rx). Bridge them with R3's `ToObservable()` / `AsSystemObservable()` rather than
   retyping the declarations.
+- **DataAnnotations validation that must stay eager.** The skill rewrites single-property
+  DataAnnotations to `EnableValidation()`, which validates lazily — see the **Validation timing**
+  note above. If you relied on eager validation (for example in headless tests), switch that
+  property to `ValidatableReactiveProperty<T>`.
 
 You can invoke the whole flow with requests as simple as "migrate this app to R3", "replace
 ReactiveProperty with R3", or "move this ViewModel off ReactiveProperty".


### PR DESCRIPTION
Adds the missing automated safety net for the shipped R3 migration sample, plus the maintainer-facing evaluation evidence and user-doc pointers. This is the upstreamed, deduplicated result of the CLI-driven skill evaluation (the lab `01-before`/`03-completed` snapshots are intentionally **not** committed — they largely duplicate the existing `ReactivePropertySamples.WPF` ↔ `ReactivePropertySamples.R3.WPF` before/after pair; only the genuinely additive parts are upstreamed here).

## What this adds
**1. Sample test project (the real additive value).** `Samples/ReactivePropertySamples.R3.Tests/` — 15 MSTest cases across 5 files covering the already-shipped migrated ViewModels in `ReactivePropertySamples.R3.Shared`, which previously had **zero** tests:
- `ValidationViewModelTests` (5) — DataAnnotations transitions, eager `ValidatableReactiveProperty`, `IgnoreInitialValidationError`, `ToReactivePropertyAsSynchronized` two-way, SubmitCommand gating.
- `ReactiveCommandViewModelTests` (3) — `ReactiveCommand`, `IObservable<bool>`-gated `CanExecute`, `ReactiveCommand<string>` parameter.
- `CreateFromPocoViewModelTests` (3) — two-way / one-way / one-way-to-source POCO sync.
- `EventToReactiveViewModelTests` (2) — `OpenFileCommand` output + `CanExecute` gate.
- `CollectionsViewModelTests` (2) — synchronous `ReactiveCommand` + `ObservableCollection` path. Time/thread-dependent VMs (`BasicUsages` `Delay`, `Guid` threadpool, `FilteredItems` timer) are excluded by design with a documented file comment.

Tests assert validation on transitions to sidestep R3's lazy `EnableValidation` (see the evaluation note). CPM (versionless `PackageReference`), relative `ProjectReference`, `net10.0` (no WPF dependency), file-scoped namespaces, UTF-8 BOM.

**2. Scoped gating CI.** `.github/workflows/samples-r3-tests.yml` runs `dotnet test` on just this one project (windows-latest, .NET 10) on PRs to `main` / `feature/r3-migration-support`. Scoping keeps it fast — it does not build the heavy WPF/Blazor/Prism/MahApps samples.

**3. Maintainer evaluation note.** `dev-docs/r3-migration/skill-evaluation.md` distills the CLI-driven skill evaluation: the SKILL.md YAML frontmatter bug (fixed), out-of-tree `view`-scoping vs. install path, the `EnableValidation` lazy-validation nuance, and the per-symbol conformance summary. Linked from ADR-0003 and `design.md`. No new ADR.

**4. User-doc pointers.** `docs/docs/advanced/r3-migration.md` gains a "Runnable sample" before/after pointer and a cross-reference to the existing validation-timing note (no duplication).

## Verification
- `dotnet test Samples/ReactivePropertySamples.R3.Tests/...` → **15 passed, 0 failed, 0 skipped** (independently re-run from a clean checkout).
- R3 WPF sample + Shared + bridge build clean.
- `Directory.Packages.props` unchanged (all versions already pinned). No `Source/` or existing sample ViewModel files modified — additive only (12 files, +440).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
