### PR TITLE
Use NuGet trusted publishing

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -52,13 +52,21 @@ jobs:
   release-to-nuget:
     runs-on: windows-latest
     needs: build
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: Download archives
         uses: actions/download-artifact@v4
         with:
           name: dist
+      - name: NuGet login (OIDC)
+        id: login
+        uses: NuGet/login@v1
+        with:
+          user: ${{ secrets.NUGET_USER }}
       - name: Publish packages
-        run: dotnet nuget push **/*.nupkg --skip-duplicate -k ${{ secrets.NUGET_APIKEY }} -s https://api.nuget.org/v3/index.json
+        run: dotnet nuget push **/*.nupkg --skip-duplicate --api-key ${{ steps.login.outputs.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
 
   create-release:
     runs-on: windows-latest


### PR DESCRIPTION
NuGet publishing now uses Trusted Publishing instead of the removed long-lived `NUGET_APIKEY` repository secret.

This updates the tag-triggered publish job to request an OIDC token with `id-token: write`, log in through `NuGet/login@v1` using `secrets.NUGET_USER`, and pass the short-lived token output to `dotnet nuget push`. The workflow intentionally does not set a GitHub environment, so the matching nuget.org Trusted Publishing policy should leave Environment blank.

Validation: `dotnet test ReactiveProperty.slnx --verbosity minimal`