### PR TITLE
Reword getting-started headings in docs

### DIFF
--- a/docs/docs-ja/README.md
+++ b/docs/docs-ja/README.md
@@ -132,7 +132,7 @@ class ViewModel
 
 - [サンプル](samples.md)
 
-## 始めましょう！
+## クイックスタート
 
 ReactiveProperty は次のリンクから使い始めることができます。
 

--- a/docs/docs-ja/advanced/work-with-other-mvvm-framwork.md
+++ b/docs/docs-ja/advanced/work-with-other-mvvm-framwork.md
@@ -5,7 +5,7 @@ ReactiveProperty は ViewModel やその他のレイヤー向けの基底クラ�
 
 このセクションでは、ReactiveProperty を Prism と一緒に使う方法を説明します。
 
-始めましょう！
+それでは始めましょう。
 
 ## Prism プロジェクトを作成する
 

--- a/docs/docs/README.md
+++ b/docs/docs/README.md
@@ -132,7 +132,7 @@ Cool! It is really declarative and clear.
 
 - [Samples](samples.md)
 
-## Let's start!
+## Getting started
 
 You can start using ReactiveProperty from the following links.
 


### PR DESCRIPTION
## Why

The navigation heading `## Let's start!` / `## 始めましょう！` in the docs READMEs read more like a spoken exclamation than a section label. As official documentation, the Japanese `始めましょう！` in particular felt unnatural to a native speaker as a heading, and the English exclamation is more casual than the usual OSS convention.

## What changed

- `docs/docs/README.md`: heading `## Let's start!` -> `## Getting started` (standard OSS convention).
- `docs/docs-ja/README.md`: heading `## 始めましょう！` -> `## クイックスタート` (a natural noun-phrase heading).
- `docs/docs-ja/advanced/work-with-other-mvvm-framwork.md`: body call-to-action `始めましょう！` -> `それでは始めましょう。` for a smoother sentence.

## Notes

- The English body sentence `Let's get started!` in the MVVM interop guide was left as-is; as inline prose it reads naturally.
- Docs-only change. No anchor links referenced the old headings, so there are no broken links.